### PR TITLE
Debugger breaks on try catch block in DefaultNamingSubSystem when trying to make a generic type

### DIFF
--- a/src/Castle.Windsor/MicroKernel/SubSystems/Naming/DefaultNamingSubSystem.cs
+++ b/src/Castle.Windsor/MicroKernel/SubSystems/Naming/DefaultNamingSubSystem.cs
@@ -345,6 +345,7 @@ namespace Castle.MicroKernel.SubSystems.Naming
 			handlerByServiceCache = null;
 		}
 
+		[DebuggerHidden] // prevents the debugger from braking in the try catch block when debugger option 'thrown' is set
 		protected bool IsAssignable(Type thisOne, Type fromThisOne)
 		{
 			if (thisOne.IsAssignableFrom(fromThisOne))


### PR DESCRIPTION
There is a debugger issue with the IsAssignable(Type thisOne, Type fromThisOne) function. When the debugger option "break on thrown Exceptions" is set, the debugger will break in the line 366 where the generic type is tried to make. With the [DebuggerHidden] attribute this issue could be prevented....hisOne) function. When the debugger option "break on thrown Exceptions" is set, the debugger will break in the line 366 where the generic type is tried to make. With the [DebuggerHidden] attribute this issue could be prevented.
