### PR TITLE
Implemented support for closed generic interceptors (IOC-369)

### DIFF
--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -471,6 +471,7 @@
     <Compile Include="Generics\GenericB.cs" />
     <Compile Include="IgnoreSelectTestCase.cs" />
     <Compile Include="InterceptorLifecycleTestCase.cs" />
+    <Compile Include="Interceptors\GenericInterceptor.cs" />
     <Compile Include="Interceptors\InterceptorAttributeTestCase.cs" />
     <Compile Include="CreatingContainerTestCase.cs" />
     <Compile Include="Diagnostics\UsingContainerAsServiceLocatorDiagnosticTestCase.cs" />

--- a/src/Castle.Windsor.Tests/Interceptors/GenericInterceptor.cs
+++ b/src/Castle.Windsor.Tests/Interceptors/GenericInterceptor.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2004-2012 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Windsor.Tests.Interceptors
+{
+	using Castle.DynamicProxy;
+
+	public class GenericInterceptor<T> : IInterceptor
+	{
+		public void Intercept(IInvocation invocation)
+		{
+			invocation.Proceed();
+		}
+	}
+}

--- a/src/Castle.Windsor.Tests/InterceptorsTestCase.cs
+++ b/src/Castle.Windsor.Tests/InterceptorsTestCase.cs
@@ -216,6 +216,30 @@ namespace Castle.Windsor.Tests
 		}
 
 		[Test]
+		public void OpenGenericInterceporIsUsedAsClosedGenericInterceptor()
+		{
+			container.Register(Component.For(typeof(GenericInterceptor<>)));
+			container.Register(Component.For(typeof(CalculatorService)).Interceptors<GenericInterceptor<object>>());
+
+			var service = container.Resolve<CalculatorService>();
+
+			Assert.IsNotNull(service);
+			Assert.AreEqual(4, service.Sum(2, 2));
+		}
+
+		[Test]
+		public void ClosedGenericInterceptor()
+		{
+			container.Register(Component.For(typeof(GenericInterceptor<object>)));
+			container.Register(Component.For(typeof(CalculatorService)).Interceptors<GenericInterceptor<object>>());
+
+			var service = container.Resolve<CalculatorService>();
+
+			Assert.IsNotNull(service);
+			Assert.AreEqual(4, service.Sum(2, 2));
+		}
+
+		[Test]
 		public void ClassProxyWithAttributes()
 		{
 			container = new WindsorContainer(); // So we wont use the facilities

--- a/src/Castle.Windsor/Core/InterceptorReference.cs
+++ b/src/Castle.Windsor/Core/InterceptorReference.cs
@@ -117,8 +117,12 @@ namespace Castle.Core
 
 		private IHandler GetInterceptorHandler(IKernel kernel)
 		{
-			var handler = kernel.GetHandler(referencedComponentName);
-			return handler;
+			if (referencedComponentType != null)
+			{
+				return kernel.GetHandler(referencedComponentType);
+			}
+
+			return kernel.GetHandler(referencedComponentName);
 		}
 
 		private CreationContext RebuildContext(Type handlerType, CreationContext current)


### PR DESCRIPTION
The problem was in IntrceptorReference reference component name. 

Probably it is better to resolve interceptors by type if it is defined?

```
    public class MySuperInstaller : IWindsorInstaller
    {
        public void Install(IWindsorContainer container, IConfigurationStore store)
        {
            container.Register(
                Component.For(typeof (MyInterceptor<>)),
                Component.For<IFoo>().Interceptors<MyInterceptor<Bar>>());
        }
    }

    public class MyInterceptor<T> : IInterceptor
    {
        public void Intercept(IInvocation invocation)
        {
// Some work that depends on T
        }
    }
```
