### PR TITLE
Property injection invalidates the tests

### DIFF
--- a/src/Castle.Windsor.Tests/ClassComponents/HasTwoConstructors.cs
+++ b/src/Castle.Windsor.Tests/ClassComponents/HasTwoConstructors.cs
@@ -26,7 +26,7 @@ namespace Castle.MicroKernel.Tests.ClassComponents
 			Common = common;
 		}
 
-		public ICommon Common { get; set; }
-		public ICustomer Customer { get; set; }
+		public ICommon Common { get; private set; }
+		public ICustomer Customer { get; private set; }
 	}
 }


### PR DESCRIPTION
A few test for multiple constructors decide which one was used by checking if these properties are not null. Public setters trigger property injection and both of them are resolved. Making them private breaks the test with ServiceOverride.ForKey().Eq() though.
