### PR TITLE
AssemblyFilter to IAssemblyProvider

### DIFF
--- a/src/Castle.Windsor/MicroKernel/Registration/AllTypes.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/AllTypes.cs
@@ -18,8 +18,9 @@ namespace Castle.MicroKernel.Registration
 	using System.Collections.Generic;
 	using System.ComponentModel;
 	using System.Reflection;
+	using Castle.Core.Internal;
 
-	/// <summary>
+    /// <summary>
 	///   Describes a set of components to register in the kernel. Use static methods on the class to fluently build registration.
 	/// </summary>
 	public static class AllTypes
@@ -79,7 +80,7 @@ namespace Castle.MicroKernel.Registration
 		/// </summary>
 		/// <param name = "filter"></param>
 		/// <returns></returns>
-		public static FromAssemblyDescriptor FromAssemblyInDirectory(AssemblyFilter filter)
+		public static FromAssemblyDescriptor FromAssemblyInDirectory(IAssemblyProvider filter)
 		{
 			return Classes.FromAssemblyInDirectory(filter);
 		}

--- a/src/Castle.Windsor/MicroKernel/Registration/Classes.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Classes.cs
@@ -90,7 +90,7 @@ namespace Castle.MicroKernel.Registration
 		/// </summary>
 		/// <param name = "filter"> </param>
 		/// <returns> </returns>
-		public static FromAssemblyDescriptor FromAssemblyInDirectory(AssemblyFilter filter)
+		public static FromAssemblyDescriptor FromAssemblyInDirectory(IAssemblyProvider filter)
 		{
 			if (filter == null)
 			{


### PR DESCRIPTION
Change signature of 2 methods of the kernel registration API to use the interface IAssemblyProvider instead of using the implementation of AssemblyFilter. Now we can implement our own strategy to resolve assemblies containing types to register. 
