### PR TITLE
Allow named registrations to use IsFallback

### DIFF
--- a/src/Castle.Windsor.Tests/IsFallbackTestCase.cs
+++ b/src/Castle.Windsor.Tests/IsFallbackTestCase.cs
@@ -95,5 +95,29 @@ namespace CastleTests
 
 			Assert.IsInstanceOf<EmptyServiceA>(obj);
 		}
+
+	    [Test]
+	    public void Can_make_a_component_fallback_with_named_registration()
+	    {
+	        const string regKey = "svc_name";
+	        Container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyServiceA>().Named(regKey).IsFallback(),
+                               Component.For<IEmptyService>().ImplementedBy<EmptyServiceB>().Named(regKey));
+
+            var obj = Container.Resolve<IEmptyService>();
+
+            Assert.IsInstanceOf<EmptyServiceB>(obj);
+	    }
+
+        [Test]
+        public void Later_fallback_does_not_override_earlier_one_when_using_named_registrations()
+        {
+            const string regKey = "svc_name";
+            Container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyServiceA>().Named(regKey).IsFallback(),
+                               Component.For<IEmptyService>().ImplementedBy<EmptyServiceB>().Named(regKey).IsFallback());
+
+            var obj = Container.Resolve<IEmptyService>();
+
+            Assert.IsInstanceOf<EmptyServiceA>(obj);
+        }
 	}
 }

--- a/src/Castle.Windsor/MicroKernel/SubSystems/Naming/DefaultNamingSubSystem.cs
+++ b/src/Castle.Windsor/MicroKernel/SubSystems/Naming/DefaultNamingSubSystem.cs
@@ -243,6 +243,24 @@ namespace Castle.MicroKernel.SubSystems.Naming
 			var name = handler.ComponentModel.Name;
 			using (@lock.ForWriting())
 			{
+                if (name2Handler.ContainsKey(name))
+                {
+                    var existingComponent = name2Handler[name].ComponentModel;
+                    bool isFallback = handler.ComponentModel.GetFallbackComponentForServiceFilter() != null;
+                    bool hasExistingFallback = existingComponent.GetFallbackComponentForServiceFilter() != null;
+                    
+                    if (!isFallback && hasExistingFallback)
+                    {
+                        // Replace the existing fallback
+                        name2Handler.Remove(name);
+                    }
+                    else if (isFallback && hasExistingFallback)
+                    {
+                        // Do not register a second fallback, first fallback wins
+                        return; 
+                    }
+                }
+
 				try
 				{
 					name2Handler.Add(name, handler);


### PR DESCRIPTION
I need to be able to register a named component as a fallback, allowing a plugin to later register a different implementation using the same name.

When adding a named registration, if an existing fallback is registered under the same name, replace it. If the new registration is also a fallback, it is ignored (which is consistent with the current non-named registration behavior).