### PR TITLE
Pre-Loadable concept

### DIFF
--- a/Castle.Windsor.sln.DotSettings
+++ b/Castle.Windsor.sln.DotSettings
@@ -259,6 +259,7 @@ limitations under the License.&#xD;
 	<s:Boolean x:Key="/Default/Environment/Editor/UseCamelHumps/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/ExternalSources/Decompiler/DecompileMethodBodies/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/ExternalSources/Decompiler/ReorderMembers/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UserInterface/ThemedIcon/IconThemeSelection/@EntryValue">Color</s:String>
 	<s:String x:Key="/Default/Environment/UserInterface/ThemedIcon/PsiSymbolIcon/PsiSymbolIconThemeSelection/@EntryValue">SymbolsVs11Color</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -517,6 +517,7 @@
     <Compile Include="ConventionVerification.cs" />
     <Compile Include="ContainerExtensions\BadDependencyResolver.cs" />
     <Compile Include="ContainerExtensions\GoodDependencyResolver.cs" />
+    <Compile Include="ResolveLongRunningTestCase.cs" />
     <Compile Include="DependencyCyclesTestCase.cs" />
     <Compile Include="Diagnostics\AllServicesDiagnosticTestCase.cs" />
     <Compile Include="Diagnostics\DuplicatedDependenciesDiagnosticTestCase.cs" />

--- a/src/Castle.Windsor.Tests/ResolveLongRunningTestCase.cs
+++ b/src/Castle.Windsor.Tests/ResolveLongRunningTestCase.cs
@@ -1,0 +1,41 @@
+// Copyright 2004-2012 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests
+{
+	using Castle.MicroKernel.Handlers;
+	using Castle.MicroKernel.Registration;
+
+	using CastleTests.Components;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+    public class ResolveLongRunningTestCase : AbstractContainerTestCase
+	{
+		[Test]
+		public void Can_Resolve_Only_Long_Running_Services()
+		{
+            // Arrange
+			Container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyServiceA>().IsLongRunning(),
+			                   Component.For<IEmptyService>().ImplementedBy<EmptyServiceB>());
+
+            // Act
+			var services = Container.ResolveAllLongRunning<IEmptyService>();
+
+            // Assert
+			Assert.AreEqual(1, services.Length);
+		}
+	}
+}

--- a/src/Castle.Windsor/Core/Internal/Constants.cs
+++ b/src/Castle.Windsor/Core/Internal/Constants.cs
@@ -21,6 +21,7 @@ namespace Castle.Core.Internal
 		private const string genericImplementationMatchingStrategy = "castle.generic-matching-strategy";
 		private const string genericServiceStrategy = "castle.generic-service-strategy";
 		private const string helpLink = @"groups.google.com/group/castle-project-users";
+        private const string longRunningResolve = "castle.long-running-resolve";
 
 		private const string propertyFilters = "castle.property-filters";
 		private const string scopeAccessorType = "castle.scope-accessor-type";
@@ -47,10 +48,15 @@ namespace Castle.Core.Internal
 			get { return genericImplementationMatchingStrategy; }
 		}
 
-		public static string GenericServiceStrategy
-		{
-			get { return genericServiceStrategy; }
-		}
+        public static string GenericServiceStrategy
+        {
+            get { return genericServiceStrategy; }
+        }
+
+        public static string LongRunningResolve
+        {
+            get { return longRunningResolve; }
+        }
 
 		public static object PropertyFilters
 		{

--- a/src/Castle.Windsor/MicroKernel/IKernelInternal.cs
+++ b/src/Castle.Windsor/MicroKernel/IKernelInternal.cs
@@ -68,5 +68,7 @@ namespace Castle.MicroKernel
 		IHandler CreateHandler(ComponentModel model);
 
 		void RaiseEventsOnHandlerCreated(IHandler handler);
+
+	    Array ResolveAllLongRunning(Type service, IDictionary arguments, IReleasePolicy policy);
 	}
 }

--- a/src/Castle.Windsor/MicroKernel/IKernel_Resolve.cs
+++ b/src/Castle.Windsor/MicroKernel/IKernel_Resolve.cs
@@ -140,6 +140,26 @@ namespace Castle.MicroKernel
 		/// </summary>
 		/// <typeparam name = "TService"></typeparam>
 		/// <returns></returns>
-		TService[] ResolveAll<TService>(object argumentsAsAnonymousType);
+        TService[] ResolveAll<TService>(object argumentsAsAnonymousType);
+
+        /// <summary>
+        /// Resolves all component instances that are marked with the long running flag.
+        /// </summary>
+        void ResolveAllLongRunning();
+
+        /// <summary>
+        ///   Returns all the valid component instances by
+        ///   the service type marked with the is long running flag
+        /// </summary>
+        /// <param name = "service">The service type</param>
+        Array ResolveAllLongRunning(Type service);
+
+        /// <summary>
+        ///   Returns all the valid component instances by
+        ///   the service type marked with the is long running flag
+        /// </summary>
+        /// <param name = "service">The service type</param>
+        /// <param name = "arguments">Arguments to resolve the services</param>
+        Array ResolveAllLongRunning(Type service, IDictionary arguments);
 	}
 }

--- a/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
@@ -1179,6 +1179,18 @@ namespace Castle.MicroKernel.Registration
 			return IsFallback(_ => true);
 		}
 
+        /// <summary>
+        /// Sets a flag to indicate the the TService is a task that is long running when the resolve method is called.
+        /// This should be mostly used on web services or services that can be pre-resolved as part of a splash screen.
+        /// </summary>
+        /// <returns>The current instance of <see cref="ComponentRegistration{TService}"/></returns>
+        public ComponentRegistration<TService> IsLongRunning()
+        {
+            var properties = new Property(Constants.LongRunningResolve, true);
+
+            return ExtendedProperties(properties);
+        }
+
 		/// <summary>
 		/// Filters (settable) properties of the component's implementation type to expose in the container.
 		/// </summary>

--- a/src/Castle.Windsor/Windsor/IWindsorContainer.cs
+++ b/src/Castle.Windsor/Windsor/IWindsorContainer.cs
@@ -239,7 +239,7 @@ namespace Castle.Windsor
 		///   Resolve all valid components that match this type.
 		/// </summary>
 		/// <typeparam name = "T">The service type</typeparam>
-		T[] ResolveAll<T>();
+        T[] ResolveAll<T>();
 
 		/// <summary>
 		///   Resolve all valid components that match this service
@@ -273,6 +273,52 @@ namespace Castle.Windsor
 		///   <typeparam name = "T">The service type</typeparam>
 		///   <param name = "argumentsAsAnonymousType">Arguments to resolve the service</param>
 		/// </summary>
-		T[] ResolveAll<T>(object argumentsAsAnonymousType);
+        T[] ResolveAll<T>(object argumentsAsAnonymousType);
+
+        /// <summary>
+        /// Pre resolves all components and services marked with the long running flag.
+        /// </summary>
+        void ResolveAllLongRunning();
+
+        /// <summary>
+        ///   Resolve all marked with the IsLongRunning flag.
+        /// </summary>
+        /// <typeparam name = "T">The service type</typeparam>
+        T[] ResolveAllLongRunning<T>();
+
+		/// <summary>
+        ///   Resolve all valid components that match this service marked with the IsLongRunning flag.
+		///   <param name = "service">the service to match</param>
+		/// </summary>
+        Array ResolveAllLongRunning(Type service);
+
+		/// <summary>
+        ///   Resolve all valid components that match this service that are
+        ///   also marked with the IsLongRunning flag.
+		/// <param name = "service">the service to match</param>
+		/// <param name = "arguments">Arguments to resolve the service</param>
+		/// </summary>
+        Array ResolveAllLongRunning(Type service, IDictionary arguments);
+
+		/// <summary>
+        ///   Resolve all valid components that match this service marked with the IsLongRunning flag.
+		///   <param name = "service">the service to match</param>
+		///   <param name = "argumentsAsAnonymousType">Arguments to resolve the service</param>
+		/// </summary>
+        Array ResolveAllLongRunning(Type service, object argumentsAsAnonymousType);
+
+		/// <summary>
+        ///   Resolve all valid components that match this type marked with the IsLongRunning flag.
+		///   <typeparam name = "T">The service type</typeparam>
+		///   <param name = "arguments">Arguments to resolve the service</param>
+		/// </summary>
+        T[] ResolveAllLongRunning<T>(IDictionary arguments);
+
+		/// <summary>
+        ///   Resolve all valid components that match this type marked with the IsLongRunning flag.
+		///   <typeparam name = "T">The service type</typeparam>
+		///   <param name = "argumentsAsAnonymousType">Arguments to resolve the service</param>
+		/// </summary>
+        T[] ResolveAllLongRunning<T>(object argumentsAsAnonymousType);
 	}
 }

--- a/src/Castle.Windsor/Windsor/WindsorContainer.cs
+++ b/src/Castle.Windsor/Windsor/WindsorContainer.cs
@@ -698,6 +698,41 @@ namespace Castle.Windsor
 			return ResolveAll<T>(new ReflectionBasedDictionaryAdapter(argumentsAsAnonymousType));
 		}
 
+	    public void ResolveAllLongRunning()
+	    {
+            kernel.ResolveAllLongRunning();
+	    }
+
+	    public T[] ResolveAllLongRunning<T>()
+	    {
+            return (T[])ResolveAllLongRunning(typeof(T));
+	    }
+
+	    public Array ResolveAllLongRunning(Type service)
+	    {
+            return kernel.ResolveAllLongRunning(service);
+	    }
+
+	    public Array ResolveAllLongRunning(Type service, IDictionary arguments)
+	    {
+            return kernel.ResolveAllLongRunning(service, arguments);
+	    }
+
+	    public Array ResolveAllLongRunning(Type service, object argumentsAsAnonymousType)
+	    {
+            return ResolveAllLongRunning(service, new ReflectionBasedDictionaryAdapter(argumentsAsAnonymousType));
+	    }
+
+	    public T[] ResolveAllLongRunning<T>(IDictionary arguments)
+	    {
+            return (T[])ResolveAllLongRunning(typeof(T), arguments);
+	    }
+
+	    public T[] ResolveAllLongRunning<T>(object argumentsAsAnonymousType)
+	    {
+            return ResolveAllLongRunning<T>(new ReflectionBasedDictionaryAdapter(argumentsAsAnonymousType));
+	    }
+
 #if !SILVERLIGHT
 		private XmlInterpreter GetInterpreter(string configurationUri)
 		{


### PR DESCRIPTION
I am currently building a system at work were i have a collection of WCF
services that take an extended period of time to resolve.

We use these services to initilize our data but the service itself is
obviously resolved only when when inject it.

In a different world we could add the call to the splash screen and have
it load all the data there but the design is to only request the data as
we need it, not all at once.

So the way we got round this was to call .Resolve on all our WCF
services. This just seemed a little dirty to me. I also realized that we
must not be the only ones that need to do this. so this is my attempt at
allowing for this Pre-resolve behaviour.

If you have any thoughts on a better way to have implemented this pre-load concept, let me know and i will try to re-write.

My original idea was to try to use the ResolveAll method but add a temporary handlerSelector but that seemed like it was a bit of a hack
