### PR TITLE
Fix broken link

### DIFF
--- a/docs/whats-new-3.1.md
+++ b/docs/whats-new-3.1.md
@@ -93,4 +93,4 @@ Notice that similar overload exists for log4Net since Windsor 3.0.
 
 ## See also
 
-* [What's new in Windsor 3.0](whats-new-3.0..md)
+* [What's new in Windsor 3.0](whats-new-3.0.md)


### PR DESCRIPTION
Fix link to "What's new in 3.0" to correctly reference file name