### PR TITLE
Fix case sensitivity issue that can cause UsingFactoryMethod to fail …

### DIFF
--- a/src/Castle.Windsor.Tests/TypeNameConverterTestCase.cs
+++ b/src/Castle.Windsor.Tests/TypeNameConverterTestCase.cs
@@ -262,5 +262,22 @@ namespace CastleTests
 
 			Assert.AreEqual(message, exception.Message);
 		}
+
+		class TestCaseSensitivity { }
+		class TESTCASESENSITIVITY { }
+
+		[Test]
+		public void Can_resolve_exact_match_if_two_classes_exist_that_differ_only_by_case()
+		{
+			var type = typeof(IGeneric<TestCaseSensitivity>);
+			var name = type.AssemblyQualifiedName;
+			var result = converter.PerformConversion(name, typeof(Type));
+			Assert.AreEqual(type, result);
+
+			var type2 = typeof(IGeneric<TESTCASESENSITIVITY>);
+			var name2 = type2.AssemblyQualifiedName;
+			var result2 = converter.PerformConversion(name2, typeof(Type));
+			Assert.AreEqual(type2, result2);
+		}
 	}
 }

--- a/src/Castle.Windsor/MicroKernel/SubSystems/Conversion/TypeNameConverter.cs
+++ b/src/Castle.Windsor/MicroKernel/SubSystems/Conversion/TypeNameConverter.cs
@@ -85,7 +85,14 @@ namespace Castle.MicroKernel.SubSystems.Conversion
 
 		private Type GetType(string name)
 		{
-			var type = Type.GetType(name, false, true);
+			// try to create type using case sensitive search first.
+			var type = Type.GetType(name, false, false);
+			if (type != null)
+			{
+				return type;
+			}
+			// if case sensitive search did not create the type, try case insensitive.
+			type = Type.GetType(name, false, true);
 			if (type != null)
 			{
 				return type;


### PR DESCRIPTION
…if 2 class names only differ by case.

We use an obfuscator that will generate class names that only differ by case. This was causing an issue if one of these classes was registered with UsingFactoryMethod. A class of type FactoryMethodActivator&lt;T&gt; is created with the wrong type parameter because it will create a class of FactoryMethodActivator&lt;t&gt; instead which caused the registration to fail.

