### PR TITLE
Fixed syntax error in example code.

### DIFF
--- a/docs/registering-components-one-by-one.md
+++ b/docs/registering-components-one-by-one.md
@@ -32,8 +32,8 @@ Note that `For` and `ImplementedBy` also have non-generic overloads.
 ```csharp
 // Same result as example above.
 container.Register(
-    Component.For(typeof(IMyService)
-        .ImplementedBy(typeof(MyServiceImpl)
+    Component.For(typeof(IMyService))
+        .ImplementedBy(typeof(MyServiceImpl))
 );
 ```
 


### PR DESCRIPTION
Added missing parenthesis to overloaded For and ImplementedBy example code.