### PR TITLE
All implicit object casts fixed. Fixes #127

### DIFF
--- a/src/Castle.Facilities.WcfIntegration/Behaviors/Security/FetchCertificate.cs
+++ b/src/Castle.Facilities.WcfIntegration/Behaviors/Security/FetchCertificate.cs
@@ -23,7 +23,7 @@ namespace Castle.Facilities.WcfIntegration.Behaviors
 
 		public static implicit operator AbstractCredentials(FetchCertificate finder)
 		{
-			return new CertificateCredentials(finder);
+			return finder == null ? null : new CertificateCredentials(finder);
 		}
 	}
 }

--- a/src/Castle.Facilities.WcfIntegration/Behaviors/Security/FetchCertificateBySubject.cs
+++ b/src/Castle.Facilities.WcfIntegration/Behaviors/Security/FetchCertificateBySubject.cs
@@ -20,7 +20,7 @@ namespace Castle.Facilities.WcfIntegration.Behaviors
 
 		public static implicit operator AbstractCredentials(FetchCertificateBySubject finder)
 		{
-			return new CertificateCredentials(finder);
+			return finder == null ? null : new CertificateCredentials(finder);
 		}
 	}
 }

--- a/src/Castle.Windsor/MicroKernel/Registration/Parameter.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Parameter.cs
@@ -74,7 +74,7 @@ namespace Castle.MicroKernel.Registration
 
 		public static implicit operator Dependency(Parameter parameter)
 		{
-			return new Dependency(parameter);
+			return parameter == null ? null : new Dependency(parameter);
 		}
 	}
 

--- a/src/Castle.Windsor/MicroKernel/Registration/Property.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Property.cs
@@ -80,7 +80,7 @@ namespace Castle.MicroKernel.Registration
 
 		public static implicit operator Dependency(Property item)
 		{
-			return new Dependency(item);
+			return item == null ? null : new Dependency(item);
 		}
 	}
 

--- a/src/Castle.Windsor/MicroKernel/Registration/ServiceOverride.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ServiceOverride.cs
@@ -79,7 +79,7 @@ namespace Castle.MicroKernel.Registration
 		/// <returns></returns>
 		public static implicit operator Dependency(ServiceOverride item)
 		{
-			return new Dependency(item);
+			return item == null ? null : new Dependency(item);
 		}
 	}
 


### PR DESCRIPTION
As described in #127 this makes sure that imlicit casts do not create objects out of thin air.