### PR TITLE
Fixed link in documentation

### DIFF
--- a/docs/fluent-registration-api.md
+++ b/docs/fluent-registration-api.md
@@ -22,7 +22,7 @@ Recommended approach to registering components is to do it using convention driv
 
 ## Proxies
 
-[Registering interceptors and proxy options](registering-interceptors-proxyoptions.md).
+[Registering interceptors and proxy options](registering-interceptors-and-proxyoptions.md).
 
 ## Advanced topics
 


### PR DESCRIPTION
Fixed link in "Fluent Registration API" documentation.
Link to "Registering Interceptors and ProxyOptions" was incorrect.