### PR TITLE
Fixed test with weak reference in .NET 4.6.x

### DIFF
--- a/src/Castle.Windsor.Tests/Lifestyle/ScopedLifestyleTestCase.cs
+++ b/src/Castle.Windsor.Tests/Lifestyle/ScopedLifestyleTestCase.cs
@@ -186,12 +186,20 @@ namespace CastleTests.Lifestyle
 
 			using (Container.BeginScope())
 			{
-				var udf = Container.Resolve<UsesDisposableFoo>();
-				var weakUdt = new WeakReference(udf);
-				udf = null;
+				var weakUdt = GetWeakReferenceToDisposableFoo();
 				GC.Collect();
 				Assert.IsFalse(weakUdt.IsAlive);
 			}
+		}
+
+		// method is needed because since 4.6.x under debug configuration local variables are not
+		// considered for garbage collection; hence if method is inlined - test will fail
+		private WeakReference GetWeakReferenceToDisposableFoo()
+		{
+			var udf = Container.Resolve<UsesDisposableFoo>();
+			var weakUdt = new WeakReference(udf);
+			udf = null;
+			return weakUdt;
 		}
 
 		[Test]


### PR DESCRIPTION
See comment in the code changes and a similar issue here: http://stackoverflow.com/questions/32876653/net-4-x-how-to-force-full-gc-collection