### PR TITLE
Fix unit test incorrectly depending on source file line endings

### DIFF
--- a/src/Castle.Windsor.Tests/Registration/UsingFactoryMethodTestCase.cs
+++ b/src/Castle.Windsor.Tests/Registration/UsingFactoryMethodTestCase.cs
@@ -453,8 +453,8 @@ namespace CastleTests.Registration
 				Assert.Throws<InvalidProxyConstructorArgumentsException>(() => Kernel.Resolve<ClassWithConstructors>());
 
 			var expected =
-				@"Can not instantiate proxy of class: Castle.MicroKernel.Tests.Configuration.Components.ClassWithConstructors.
-Could not find a parameterless constructor.";
+				"Can not instantiate proxy of class: Castle.MicroKernel.Tests.Configuration.Components.ClassWithConstructors." + Environment.NewLine +
+				"Could not find a parameterless constructor.";
 
 			Assert.AreEqual(expected, exception.Message);
 		}


### PR DESCRIPTION
TeamCity uses jgit which doesn't support gitattributes yet, so resolving mixed line endings caused this unit test to fail.