### PR TITLE
Fix for issue #146: Performance Counter Instances Never Removed

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -975,3 +975,5 @@ Beta 1  - 21/jan/2005
 - Fixed: Remove method
 
 - Fixed: Windsor: Proxy for components with (service != impl)
+
+- Changed: Performance Counter InstanceLifetime

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,5 @@
+- fixed #146 - Changed Performance Counter InstanceLifetime
+
 3.3.0
 ==================
 - implemented #57 - build NuGet and Zip packages from TeamCity - contributed by Blair Conrad (@blairconrad)
@@ -975,5 +977,3 @@ Beta 1  - 21/jan/2005
 - Fixed: Remove method
 
 - Fixed: Windsor: Proxy for components with (service != impl)
-
-- Changed: Performance Counter InstanceLifetime

--- a/docs/performance-counters.md
+++ b/docs/performance-counters.md
@@ -17,7 +17,7 @@ var counter = LifecycledComponentsReleasePolicy.GetTrackedComponentsPerformanceC
 container.Kernel.ReleasePolicy = new LifecycledComponentsReleasePolicy(diagnostic, counter);
 ```
 
-Then Windsor will inspect if it has all required permissions, and if it does, it will ensure the right category and counters are created and will update the counter as the application(s) run.
+Then Windsor will inspect if it has all required permissions, and if it does, it will ensure the right category and counters are created and will update the counter as the application(s) run. The created counter instances will exist for the lifetime of the process and will be removed when the process closes.
 
 In order to see the data open Performance Monitor (part of Computer Management console accessible from Administrative Tools section of your Windows Control Panel). Then click Add (Ctrl+N) and find "Castle Windsor" section. As noted above it will contain just one counter - "Objects tracked by release policy", and list of its instances.
 

--- a/src/Castle.Windsor/Windsor/Diagnostics/PerformanceMetricsFactory.cs
+++ b/src/Castle.Windsor/Windsor/Diagnostics/PerformanceMetricsFactory.cs
@@ -55,10 +55,15 @@ namespace Castle.Windsor.Diagnostics
 			}
 			try
 			{
-				return new PerformanceCounter(CastleWindsorCategoryName,
-				                              InstanesTrackedByTheReleasePolicyCounterName,
-				                              name,
-				                              readOnly: false) { RawValue = 0L };
+				return new PerformanceCounter
+				{
+					CategoryName = CastleWindsorCategoryName,
+					CounterName = InstanesTrackedByTheReleasePolicyCounterName,
+					InstanceName = name,
+					ReadOnly = false,
+					InstanceLifetime = PerformanceCounterInstanceLifetime.Process,
+					RawValue = 0L // Setting RawValue will initialize the counter so it must be set last
+				};
 			}
 			// exception types we should expect according to http://msdn.microsoft.com/en-us/library/356cx381.aspx
 			catch (Win32Exception)


### PR DESCRIPTION
The fix turned out to be quite simple (thanks @jonorossi for the tips!), the InstanceLifetime of the created PerformanceCounter had to be set to Process. This causes the created performance counter instances to be removed when the process closes.

I also updated performance-counters.md to reflect this.