### PR TITLE
Fix for Issue #71 Disposing faulted channels

### DIFF
--- a/src/Castle.Facilities.WcfIntegration/Client/WcfClientActivator.cs
+++ b/src/Castle.Facilities.WcfIntegration/Client/WcfClientActivator.cs
@@ -61,6 +61,7 @@ namespace Castle.Facilities.WcfIntegration
 
 		protected override void ApplyDecommissionConcerns(object instance)
 		{
+            WcfUtils.ReleaseCommunicationObject(instance as ICommunicationObject, null);
 			base.ApplyDecommissionConcerns(instance);
 
 			var channelHolder = (IWcfChannelHolder)instance;


### PR DESCRIPTION
Issue #71 
This code will abort any channels before before they are disposed. WcfClientActivator seemed to be the best place to check for wcf-specific state in the exception-stack.