### PR TITLE
Build unit vs integration

### DIFF
--- a/buildscripts/Build.proj
+++ b/buildscripts/Build.proj
@@ -236,7 +236,7 @@ limitations under the License.
 
 		<Message Text="Running tests from assemblies: $(TestAssemblies)" />
 		
-		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /exclude:IntegrationTest,Explicit /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(TEAMCITY_VERSION)' == '' and '$(OS)' == 'Windows_NT' " />
+		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /exclude:IntegrationTest /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(TEAMCITY_VERSION)' == '' and '$(OS)' == 'Windows_NT' " />
 		<Exec Command="$(MonoShell) $(NUnitPath)$(NUnitExecutable) $(OutputPath)Castle.Core.Tests.dll -nologo -xml=$(NUnitTestResultXmlFiles)" Condition=" '$(OS)' != 'Windows_NT' " />
 
 		<!-- TC NUnit launcher crashes on 64bit Linux with Mono

--- a/buildscripts/Build.proj
+++ b/buildscripts/Build.proj
@@ -33,7 +33,6 @@ limitations under the License.
 	<Import Project="$(BuildScriptsPath)/Castle.Common.Targets" />
 	<Import Project="$(MSBuildBinPath)/Microsoft.CSharp.Targets" Condition="($(MSBuildTargets) == '') Or ($(MSBuildTargets) == 'CSharp')" />
 
-
 	<Target Name="CheckRequiredProperties">
 		<Error Condition="'$(ProjectName)' == ''" Text="The ProjectName property has not been set, please set it in Settings.proj." />
 		<Error Text="The tools version &quot;$(MSBuildToolsVersion)&quot; is not supported, MSBuild 4.0 or newer is required to build." Condition="'$(MSBuildToolsVersion)' != '4.0'" />
@@ -43,11 +42,9 @@ limitations under the License.
 		<Error Condition="'$(Project_Build)' == ''" Text="The Project_Build property has not been set, please set it in Settings.proj." />
 	</Target>
 		
-
 	<!--
 		Public targets
 	-->
-	
 	<Target
 		Name="BuildProject"
 		>
@@ -96,32 +93,42 @@ limitations under the License.
 
 	</Target>
 
-	
 	<Target Name="RebuildAll" DependsOnTargets="CleanAll;BuildProject" />
+	
 	<Target Name="ClickToBuild" DependsOnTargets="RebuildAll;_PreparePackage">
 		<RemoveDir Directories="$(OutputPath)" />
 	</Target>
-
+	
 	<Target Name="CleanAll">
 		<MSBuild Projects="$(SolutionPath)" Targets="Clean" Properties="Configuration=$(Configuration);BuildConstants=$(BuildConstants);MSBuildTargets=$(MSBuildTargets);TargetFrameworkVersion=$(TargetFrameworkVersion)" />
 
 		<CreateItem Include="**/Debug/**/*.*;**/Release/**/*.*">
 			<Output ItemName="_binaryFiles" TaskParameter="Include"/>
 		</CreateItem>
+		
 		<Delete Files="@(_binaryFiles)" TreatErrorsAsWarnings="true"/>
+		
 		<Exec Command="for /f %%d in ('dir /ad /b') do rd /s /q %%d"
 			WorkingDirectory="$(BuildPath)"
 			Condition=" Exists('$(BuildPath)') "/>
   		<RemoveDir Directories="$(BuildPath)" Condition=" Exists('$(BuildPath)') "/>
 	</Target>
 
-	
 	<Target
 		Name="RunAllTests"
 		DependsOnTargets="BuildProject"
 		>
 		
 		<CallTarget Targets="_ExecTestRunner" />
+	
+	</Target>
+	
+	<Target
+		Name="RunUnitTests"
+		DependsOnTargets="BuildProject"
+		>
+		
+		<CallTarget Targets="_ExecTestRunner_Without_IntegrationTest" />
 	
 	</Target>
 
@@ -167,10 +174,17 @@ limitations under the License.
 		Condition="$(TestRunner_Enabled)"
 		>
 		
-		<CallTarget Targets="_ExecNUnit" Condition="$(BuildConfigKey) != 'SL5' and $(BuildConfigKey) != 'SL4'" />
+		<CallTarget Targets="_ExecNUnit" />
 	
-		<CallTarget Targets="_ExecStatLight" Condition="$(BuildConfigKey) == 'SL5' or $(BuildConfigKey) == 'SL4'" />
-
+	</Target>
+	
+	<Target
+		Name="_ExecTestRunner_Without_IntegrationTest"
+		Condition="$(TestRunner_Enabled)"
+		>
+		
+		<CallTarget Targets="_ExecNUnit_Without_IntegrationTest" />
+	
 	</Target>
 	
 
@@ -207,24 +221,37 @@ limitations under the License.
 
 	</Target>
 
-
 	<Target
-		Name="_ExecStatLight"
+		Name="_ExecNUnit_Without_IntegrationTest"
 		>
 
-		<CreateProperty Value='$(ToolsPath)\StatLight\StatLight.exe -b -x="$(OutputPath)Castle.Windsor.Tests.xap" -o=NUnit'>
-			<Output PropertyName="StatLightCmdLine" TaskParameter="Value"/>
+		<CreateProperty Value="$(TestResultsPath)/nunit-results.xml" Condition="'$(NUnitTestResultXmlFiles)' == ''">
+			<Output PropertyName="NUnitTestResultXmlFiles" TaskParameter="Value"/>
 		</CreateProperty>
-
-		<CreateProperty Value='$(StatLightCmdLine) --teamcity' Condition=" '$(TEAMCITY_VERSION)' != '' ">
-			<Output PropertyName="StatLightCmdLine" TaskParameter="Value"/>
+		<CreateProperty Value="v4.0" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
+			<Output PropertyName="TargetFrameworkVersion" TaskParameter="Value" />
 		</CreateProperty>
+		
+		<MakeDir Directories="$(TestResultsPath)" Condition="'$(TestResultsPath)' != '' And !Exists('$(TestResultsPath)')" />
 
-		<Exec Command="$(StatLightCmdLine)" />
+		<Message Text="Running tests from assemblies: $(TestAssemblies)" />
+		
+		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /exclude:IntegrationTest,Explicit /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(TEAMCITY_VERSION)' == '' and '$(OS)' == 'Windows_NT' " />
+		<Exec Command="$(MonoShell) $(NUnitPath)$(NUnitExecutable) $(OutputPath)Castle.Core.Tests.dll -nologo -xml=$(NUnitTestResultXmlFiles)" Condition=" '$(OS)' != 'Windows_NT' " />
+
+		<!-- TC NUnit launcher crashes on 64bit Linux with Mono
+		<Exec Command="$(MonoShell) S(teamcity_dotnet_nunitlauncher) mono-2.0 x86 NUnit-2.5.5 $(OutputPath)Castle.Core.Tests.dll" Condition=" '$(TEAMCITY_VERSION)' != '' and '$(OS)' != 'Windows_NT' " />
+		-->
+
+		<NUnitTeamCity
+			Assemblies="@(TestAssemblies)"
+			NUnitVersion="NUnit-2.5.5"
+			Condition=" '$(teamcity_dotnet_nunitlauncher_msbuild_task)' != ''"
+		/>
 
 	</Target>
-
-
+	
+	
 	<!-- Prepare package directory -->
 	<Target Name="_PreparePackage">
 

--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
@@ -137,6 +137,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Categories\IntegrationTestAttribute.cs" />
     <Compile Include="Client\AsyncChannelFactoryFixture.cs" />
     <Compile Include="Service\DataService\DataServiceHostFactoryFixture.cs" />
     <Compile Include="ExceptionsTestCase.cs" />

--- a/src/Castle.Facilities.WcfIntegration.Tests/Categories/IntegrationTestAttribute.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Categories/IntegrationTestAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+namespace Castle.Facilities.WcfIntegration.Tests
+{
+	using NUnit.Framework;
+
+	public class IntegrationTestAttribute : CategoryAttribute
+	{
+		public IntegrationTestAttribute() : base("IntegrationTest")
+		{
+		}
+	}
+}

--- a/src/Castle.Facilities.WcfIntegration.Tests/Client/AsyncChannelFactoryFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Client/AsyncChannelFactoryFixture.cs
@@ -6,7 +6,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using Castle.Facilities.WcfIntegration.Async;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class AsyncChannelFactoryFixture
 	{
 		[Test]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Client/Duplex/DuplexClientFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Client/Duplex/DuplexClientFixture.cs
@@ -21,7 +21,7 @@ namespace Castle.Facilities.WcfIntegration.Tests.Duplex
 	using Castle.Windsor;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class DuplexClientFixture
 	{
 		private IWindsorContainer windsorContainer;

--- a/src/Castle.Facilities.WcfIntegration.Tests/Client/Rest/RestClientFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Client/Rest/RestClientFixture.cs
@@ -25,7 +25,7 @@ namespace Castle.Facilities.WcfIntegration.Tests.Rest
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class RestClientFixture
 	{
 		[SetUp]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Client/WcfClientFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Client/WcfClientFixture.cs
@@ -41,7 +41,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using log4net.Config;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class WcfClientFixture
 	{
 		private MemoryAppender memoryAppender;

--- a/src/Castle.Facilities.WcfIntegration.Tests/ConfigFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/ConfigFixture.cs
@@ -26,7 +26,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class ConfigFixture
 	{
 		private WindsorContainer container;

--- a/src/Castle.Facilities.WcfIntegration.Tests/ExceptionsTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/ExceptionsTestCase.cs
@@ -19,7 +19,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using Castle.Facilities.WcfIntegration.Internal;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class ExceptionsTestCase
 	{
 		[Test]

--- a/src/Castle.Facilities.WcfIntegration.Tests/IssuesTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/IssuesTestCase.cs
@@ -21,7 +21,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class IssuesTestCase
 	{
 		private IWindsorContainer container;

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/DataService/DataServiceHostFactoryFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/DataService/DataServiceHostFactoryFixture.cs
@@ -24,7 +24,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 	using DataServiceHost = System.Data.Services.DataServiceHost;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class DataServiceHostFactoryFixture
 	{
 		/// <summary>

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/ContractLoadBalancePolicyFactoryTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/ContractLoadBalancePolicyFactoryTestCase.cs
@@ -22,7 +22,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class ContractLoadBalancePolicyFactoryTestCase
 	{
 		private class TestPolicy : ILoadBalancePolicy

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/FirstAvailablePolicyTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/FirstAvailablePolicyTestCase.cs
@@ -23,7 +23,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using System.Xml;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class FirstAvailablePolicyTestCase
 	{
 		#region Setup/Teardown

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/RoundRobinPolicyTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/RoundRobinPolicyTestCase.cs
@@ -23,7 +23,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using System.Xml;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class RoundRobinPolicyTestCase
 	{
 		#region Setup/Teardown

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/ScopeLoadBalancePolicyFactoryTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Discovery/LoadBalance/ScopeLoadBalancePolicyFactoryTestCase.cs
@@ -7,7 +7,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using System.Xml;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class ScopeLoadBalancePolicyFactoryTestCase
 	{
 		[Test]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Lifestyle/PerWcfOperationLifestyleTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Lifestyle/PerWcfOperationLifestyleTestCase.cs
@@ -24,7 +24,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class PerWcfOperationLifestyleTestCase
 	{
 		[SetUp]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Lifestyle/PerWcfSessionLifestyleTestCase.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Lifestyle/PerWcfSessionLifestyleTestCase.cs
@@ -26,7 +26,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class PerWcfSessionLifestyleTestCase
 	{
 		[SetUp]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/Rest/RestServiceFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/Rest/RestServiceFixture.cs
@@ -25,7 +25,7 @@ namespace Castle.Facilities.WcfIntegration.Tests.Rest
 
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class RestServiceFixture
 	{
 		[Test]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFactoryFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFactoryFixture.cs
@@ -21,7 +21,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using Castle.Windsor;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class ServiceHostFactoryFixture
 	{
 		[Test]

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
@@ -34,7 +34,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using log4net.Config;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class ServiceHostFixture
 	{
 		private MemoryAppender memoryAppender;

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/WcfServiceFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/WcfServiceFixture.cs
@@ -24,7 +24,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using Castle.Windsor;
 	using NUnit.Framework;
 
-	[TestFixture]
+	[TestFixture, IntegrationTest]
 	public class WcfServiceFixture
 	{
 		#region Setup/Teardown


### PR DESCRIPTION
A very simple turn key way running Castle Windsor tests without requiring admin privileges. 
    `build` <- still runs all tests and requires admin privs.
    `build NET40 RunUnitTests` <- Will exclude Wcf Integration tests which do not require ele. privs.