### PR TITLE
Moved Castle.Core compatibility layer down to Castle.Windsor

### DIFF
--- a/src/Castle.Windsor/Castle.Windsor.csproj
+++ b/src/Castle.Windsor/Castle.Windsor.csproj
@@ -289,6 +289,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compatibility\CustomAttributeExtensions.cs" />
+    <Compile Include="Compatibility\IntrospectionExtensions.cs" />
+    <Compile Include="Compatibility\NetCoreReflectionExtensions.cs" />
+    <Compile Include="Compatibility\RuntimeReflectionExtensions.cs" />
+    <Compile Include="Compatibility\TypeBuilderExtensions.cs" />
     <Compile Include="Core\Internal\SimpleThreadSafeCollection.cs" />
     <Compile Include="Core\Internal\SimpleThreadSafeSet.cs" />
     <Compile Include="Facilities\Startable\IStartFlagInternal.cs" />
@@ -326,7 +331,7 @@
     <Compile Include="Core\Internal\IAssemblyProvider.cs" />
     <Compile Include="Core\Internal\LateBoundComponent.cs" />
     <Compile Include="Core\Internal\ReflectionUtil.cs" />
-    <Compile Include="Compatibility\SilverlightHacks.cs" />
+    <Compile Include="Compatibility\SerializableAttribute.cs" />
     <Compile Include="Core\Internal\ThreadSafeInit.cs" />
     <Compile Include="Core\Internal\TypeByInheritanceDepthMostSpecificFirstComparer.cs" />
     <Compile Include="Core\Internal\TypeUtil.cs" />

--- a/src/Castle.Windsor/Compatibility/CustomAttributeExtensions.cs
+++ b/src/Castle.Windsor/Compatibility/CustomAttributeExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if (MONO || DOTNET35 || DOTNET40 || DOTNET45 || CLIENTPROFILE)
+
+namespace System.Reflection
+{
+	using System.Collections.Generic;
+
+	// This allows us to use the new reflection API while still supporting .NET 3.5 and 4.0.
+	//
+	// Methods like Attribute.IsDefined no longer exist in .NET Core so this provides a shim
+	// for .NET 3.5 and 4.0.
+	//
+	// This class only implemented the required extensions so add more if needed in the order
+	// from https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Extensions/ref/System.Reflection.Extensions.cs
+	internal static class CustomAttributeExtensions
+	{
+		public static IEnumerable<T> GetCustomAttributes<T>(this Assembly element) where T : Attribute
+		{
+			foreach (T a in Attribute.GetCustomAttributes(element, typeof(T)))
+			{
+				yield return a;
+			}
+		}
+
+		public static IEnumerable<T> GetCustomAttributes<T>(this MemberInfo element, bool inherit) where T : Attribute
+		{
+			foreach (T a in Attribute.GetCustomAttributes(element, typeof(T), inherit))
+			{
+				yield return a;
+			}
+		}
+
+		public static bool IsDefined(this MemberInfo element, Type attributeType)
+		{
+			return Attribute.IsDefined(element, attributeType);
+		}
+
+		public static bool IsDefined(this ParameterInfo element, Type attributeType)
+		{
+			return Attribute.IsDefined(element, attributeType);
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Windsor/Compatibility/IntrospectionExtensions.cs
+++ b/src/Castle.Windsor/Compatibility/IntrospectionExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if (MONO || DOTNET35 || DOTNET40 || DOTNET45 || CLIENTPROFILE)
+
+namespace System.Reflection
+{
+	internal static class IntrospectionExtensions
+	{
+		// This allows us to use the new reflection API which separates Type and TypeInfo
+		// while still supporting .NET 3.5 and 4.0. This class matches the API of the same
+		// class in .NET 4.5+, and so is only needed on .NET Framework versions before that.
+		//
+		// Return the System.Type for now, we will probably need to create a TypeInfo class
+		// which inherits from Type like .NET 4.5+ and implement the additional methods and
+		// properties.
+		public static Type GetTypeInfo(this Type type)
+		{
+			return type;
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Windsor/Compatibility/NetCoreReflectionExtensions.cs
+++ b/src/Castle.Windsor/Compatibility/NetCoreReflectionExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if (!MONO && !DOTNET35 && !DOTNET40 && !DOTNET45 && !CLIENTPROFILE)
+
+namespace System.Reflection
+{
+	using System.Linq;
+
+	internal static class NetCoreReflectionExtensions
+	{
+		// .NET Core needs to expose GetConstructor that takes both flags and parameter types,
+		// because we need to get the private constructor for a type with multiple constructors.
+		// It should also provide the same for GetMethod, which luckily we don't need yet.
+		public static ConstructorInfo GetConstructor(this Type type, BindingFlags bindingAttr, object binder, Type[] types, object[] modifiers)
+		{
+			if (binder != null) throw new NotSupportedException("Parameter binder must be null.");
+			if (modifiers != null) throw new NotSupportedException("Parameter modifiers must be null.");
+
+			return type.GetConstructors(bindingAttr)
+				.SingleOrDefault(ctor => ctor.GetParameters().Select(p => p.ParameterType).SequenceEqual(types));
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Windsor/Compatibility/RuntimeReflectionExtensions.cs
+++ b/src/Castle.Windsor/Compatibility/RuntimeReflectionExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if (MONO || DOTNET35 || DOTNET40 || DOTNET45 || CLIENTPROFILE)
+
+namespace System.Reflection
+{
+	// This allows us to use the new reflection API while still supporting .NET 3.5 and 4.0.
+	//
+	// Methods like Type.GetInterfaceMap no longer exist in .NET Core so this provides a shim
+	// for .NET 3.5 and 4.0.
+	internal static class RuntimeReflectionExtensions
+	{
+		// Delegate to the old name for this method.
+		public static InterfaceMapping GetRuntimeInterfaceMap(this Type type, Type interfaceType)
+		{
+			return type.GetInterfaceMap(interfaceType);
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Windsor/Compatibility/SerializableAttribute.cs
+++ b/src/Castle.Windsor/Compatibility/SerializableAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Windsor/Compatibility/TypeBuilderExtensions.cs
+++ b/src/Castle.Windsor/Compatibility/TypeBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2004-2015 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if (MONO || DOTNET35 || DOTNET40 || DOTNET45 || CLIENTPROFILE)
+
+namespace System.Reflection
+{
+	using System.Reflection.Emit;
+
+	// This allows us to use the new reflection API while still supporting .NET 3.5 and 4.0.
+	internal static class TypeBuilderExtensions
+	{
+		// TypeBuilder and GenericTypeParameterBuilder no longer inherit from Type but TypeInfo,
+		// so there is now an AsType method to get the Type which we are providing here to shim to itself.
+		public static Type AsType(this TypeBuilder builder)
+		{
+			return builder;
+		}
+
+		public static Type AsType(this GenericTypeParameterBuilder builder)
+		{
+			return builder;
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
Moved all compatibility classes from Castle.Core down to Windsor for anticipation of migration to dotnet core.