### PR TITLE
Build is now completely free of silverlight and warnings

### DIFF
--- a/src/Castle.Windsor/Castle.Windsor.csproj
+++ b/src/Castle.Windsor/Castle.Windsor.csproj
@@ -277,9 +277,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Windows" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="Castle.Core">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\$(BuildConfigKey)\Castle.Core.dll</HintPath>


### PR DESCRIPTION
This warning in the build output was annoying, also think it was something left over from silverlight