### PR TITLE
Removed superfluous references from nuspec file for Castle Windsor

### DIFF
--- a/buildscripts/Castle.Windsor.nuspec
+++ b/buildscripts/Castle.Windsor.nuspec
@@ -17,14 +17,8 @@
       <dependency id="Castle.Core" version="$CastleCoreVersion$" />
     </dependencies>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.0" />
-      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.0" />
-      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.0-Client" />
-      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.0-Client" />
       <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.5" />
       <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.5" />
-      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework3.5" />
-      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework3.5" />
     </frameworkAssemblies>
   </metadata>
   <files>


### PR DESCRIPTION
Cleaned up nuspec files. 

I must say I am hesitant to remove any of the framework assemblies on the 'Castle.WcfIntegrationFacility.nuspec' file, purely because I *think* if I remove some of these things might break. So will leave this one for now if that is OK...  