### PR TITLE
Fix the link XML configuration reference

### DIFF
--- a/docs/fluent-registration-api.md
+++ b/docs/fluent-registration-api.md
@@ -56,4 +56,4 @@ container.Install(
 * [Registering components one-by-one](registering-components-one-by-one.md)
 * [Registering components by conventions](registering-components-by-conventions.md)
 * [Windsor Installers](installers.md)
-* [XML configuration reference](XML-registration-reference.md)
+* [XML configuration reference](xml-registration-reference.md)


### PR DESCRIPTION
I checked the other 3 references to this file and they are all in lowercase correctly.