### PR TITLE
Use the latest NUnitTestAdapter for running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ _ReSharper*
 *.sln.DotSettings.user
 *.DotSettings.user
 /Packages
+/src/*/TestResults
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,15 +28,13 @@ on_finish:
 - ps: >-
     $wc = New-Object System.Net.WebClient
 
-    $testBinPath = "bin\Release\net45"
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "src\Castle.Windsor.Tests\TestResults\TestResult_Windsor.trx"))
 
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "src\Castle.Windsor.Tests\$testBinPath\TestResult_Windsor.xml"))
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "src\Castle.Facilities.WcfIntegration.Tests\TestResults\TestResult_WcfIntegration.trx"))
 
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "src\Castle.Facilities.WcfIntegration.Tests\$testBinPath\TestResult_WcfIntegration.xml"))
+    Push-AppveyorArtifact $env:APPVEYOR_BUILD_FOLDER\src\Castle.Windsor.Tests\TestResults\TestResult_Windsor.trx
 
-    Push-AppveyorArtifact $env:APPVEYOR_BUILD_FOLDER\src\Castle.Windsor.Tests\$testBinPath\TestResult_Windsor.xml
-
-    Push-AppveyorArtifact $env:APPVEYOR_BUILD_FOLDER\src\Castle.Facilities.WcfIntegration.Tests\$testBinPath\TestResult_WcfIntegration.xml
+    Push-AppveyorArtifact $env:APPVEYOR_BUILD_FOLDER\src\Castle.Facilities.WcfIntegration.Tests\TestResults\TestResult_WcfIntegration.trx
 
 build_script:  
   - cmd: build-vs2017.cmd

--- a/buildscripts/build-vs2017.cmd
+++ b/buildscripts/build-vs2017.cmd
@@ -43,9 +43,11 @@ dotnet build Castle.Windsor-VS2017.sln -c %Configuration%
 GOTO test
 
 :test
-SET nunitConsole=%UserProfile%\.nuget\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe
-SET testBin=bin\%Configuration%\net45
-%nunitConsole% src\Castle.Windsor.Tests\%testBin%\Castle.Windsor.Tests.dll --result=src\Castle.Windsor.Tests\%testBin%\TestResult_Windsor.xml
-%nunitConsole% src\Castle.Facilities.WcfIntegration.Tests\%testBin%\Castle.Facilities.WcfIntegration.Tests.dll --result=src\Castle.Facilities.WcfIntegration.Tests\%testBin%\TestResult_WcfIntegration.xml
+dotnet test ./src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj  -l "trx;LogFileName=TestResult_Windsor.trx"
+SET ERRORCOUNT=%errorlevel%
+dotnet test ./src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests-VS2017.csproj -l "trx;LogFileName=TestResult_WcfIntegration.trx"
+SET /A ERRORCOUNT=ERRORCOUNT+%errorlevel%
+EXIT /B %ERRORCOUNT%  
+
 
 

--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests-VS2017.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests-VS2017.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Castle.Core" Version="3.3.3" />
     <PackageReference Include="Castle.Core-log4net" Version="3.3.3" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit.Console" Version="3.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests-VS2017.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests-VS2017.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Castle.Core-log4net" Version="3.3.3" />
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnit.Console" Version="3.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,5 +38,4 @@
     <Reference Include="System.ServiceModel.Discovery" />
     <Reference Include="System.ServiceModel.Web" />
   </ItemGroup>
-
 </Project>

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj
@@ -47,6 +47,8 @@
     <PackageReference Include="Castle.Core-NLog" Version="3.3.0" />
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnit.Console" Version="3.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -71,5 +73,4 @@
       <SubType>Form</SubType>
     </Compile>
   </ItemGroup>
-
 </Project>

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj
@@ -46,7 +46,6 @@
     <PackageReference Include="Castle.Core-log4net" Version="3.3.0" />
     <PackageReference Include="Castle.Core-NLog" Version="3.3.0" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit.Console" Version="3.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/Castle.Windsor/Core/Internal/ReflectionUtil.cs
+++ b/src/Castle.Windsor/Core/Internal/ReflectionUtil.cs
@@ -176,6 +176,10 @@ namespace Castle.Core.Internal
 				return e.Types.FindAll(t => t != null);
 				// NOTE: perhaps we should not ignore the exceptions here, and log them?
 			}
+			catch(FileNotFoundException)
+			{
+				return new Type[] { };
+			}
 		}
 
 		public static Type[] GetAvailableTypesOrdered(this Assembly assembly, bool includeNonExported = false)


### PR DESCRIPTION
Add NUnit3TestAdapter
Use `dotnet test` for running the tests
Upload test results in trx files instead of xml
Fix the error `Could not load file or assembly Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0` by catching FileNotFoundException in `GetAvailableTypes()`
