### PR TITLE
Harmonising Castle Windsor with Castle Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ _ReSharper*
 *.sln.DotSettings.user
 *.DotSettings.user
 /Packages
+buildscripts/**/obj/
+buildscripts/**/bin/
 

--- a/Castle.Windsor-VS2017.sln
+++ b/Castle.Windsor-VS2017.sln
@@ -21,11 +21,21 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Facilities.WcfIntegr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Windsor.Tests-VS2017", "src\Castle.Windsor.Tests\Castle.Windsor.Tests-VS2017.csproj", "{11D01568-6DB2-4F82-859F-FB288A8CA694}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7E507A42-984B-470D-8A0C-648B9AF8E1DC}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Castle Build", "Castle Build", "{7E507A42-984B-470D-8A0C-648B9AF8E1DC}"
 	ProjectSection(SolutionItems) = preProject
-		common.props = common.props
-		buildscripts\CommonAssemblyInfo.cs = buildscripts\CommonAssemblyInfo.cs
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
+		build-vs2017.cmd = build-vs2017.cmd
+		CHANGELOG.md = CHANGELOG.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildScripts", "buildscripts\BuildScripts.csproj", "{944CD23E-BEF8-4FBC-A76D-7BC85A7FB2F6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Castle Facilities", "Castle Facilities", "{7935AFF5-BF6D-4D59-8D66-058B6557F70F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,8 +79,22 @@ Global
 		{11D01568-6DB2-4F82-859F-FB288A8CA694}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11D01568-6DB2-4F82-859F-FB288A8CA694}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11D01568-6DB2-4F82-859F-FB288A8CA694}.Release|Any CPU.Build.0 = Release|Any CPU
+		{944CD23E-BEF8-4FBC-A76D-7BC85A7FB2F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{944CD23E-BEF8-4FBC-A76D-7BC85A7FB2F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{944CD23E-BEF8-4FBC-A76D-7BC85A7FB2F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{944CD23E-BEF8-4FBC-A76D-7BC85A7FB2F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5538CC65-58F6-4134-9066-7BB065B16B96} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{AAEDE084-B6B6-4CD3-BD49-358758A9EB91} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{AA172172-78D8-414C-B4AB-9A8122EBB210} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{DA7B4B5F-79D7-4CFA-81B5-834F79394B09} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{BA6B28A7-C965-4F7E-8B1A-DF5171E7976B} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{2162E27E-E0EB-470A-95FD-9AD6B802D0AB} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{148CDE3A-7633-4C20-8E7E-24D5919ABACF} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{944CD23E-BEF8-4FBC-A76D-7BC85A7FB2F6} = {7E507A42-984B-470D-8A0C-648B9AF8E1DC}
 	EndGlobalSection
 EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,5 +42,5 @@ build_script:
   - cmd: build-vs2017.cmd
 
 artifacts:
- - path: Packages\*.nupkg
+ - path: build\*.nupkg
  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,3 @@
-
-pull_requests:
-  do_not_increment_build_number: true
-
 image: Visual Studio 2017
 
 build:

--- a/buildscripts/BuildScripts.csproj
+++ b/buildscripts/BuildScripts.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="common.props"></Import>
+
+	<PropertyGroup>
+		<TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<SignAssembly>False</SignAssembly>
+		<AssemblyOriginatorKeyFile>CastleKey.snk</AssemblyOriginatorKeyFile>
+		<FrameworkPathOverride Condition="'$(OS)'=='Unix'AND'$(TargetFramework)'=='net461'">$(NuGetPackageFolders)microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\</FrameworkPathOverride>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Condition="'$(OS)'=='Unix'AND'$(TargetFramework)'=='net461'" Include="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+	</ItemGroup>
+
+</Project>

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -3,20 +3,27 @@
   <PropertyGroup>
     <BuildVersion>3.4.0</BuildVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/castleproject/Windsor</RepositoryUrl>
+		<BuildVersion Condition="'$(APPVEYOR_BUILD_VERSION)'==''AND'$(APPVEYOR_REPO_TAG)'!='true'">0.0.0</BuildVersion>
+		<BuildVersion Condition="'$(APPVEYOR_BUILD_VERSION)'!=''AND'$(APPVEYOR_REPO_TAG)'!='true'">$(APPVEYOR_BUILD_VERSION)</BuildVersion>
+		<BuildVersion Condition="'$(APPVEYOR_REPO_TAG)'=='true'">$(APPVEYOR_REPO_TAG_NAME)</BuildVersion>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../buildscripts/CastleKey.snk</AssemblyOriginatorKeyFile> 
     <SignAssembly>true</SignAssembly> 
   </PropertyGroup>
 
   <PropertyGroup>
-    <Authors>Castle Project Contributors</Authors>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/castleproject/Windsor</RepositoryUrl>
+		<Product>Castle Windsor</Product>
+		<Version>$(BuildVersion)</Version>
+		<AssemblyVersion>$(BuildVersion)</AssemblyVersion>
+		<AssemblyTitle>Castle Windsor is best of breed, mature Inversion of Control container available for .NET</AssemblyTitle>
+		<Authors>Castle Project Contributors</Authors>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</PackageLicenseUrl>
     <PackageProjectUrl>http://www.castleproject.org/projects/windsor/</PackageProjectUrl>
     <PackageIconUrl>http://www.castleproject.org/img/windsor-logo.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageOutputPath>../../Packages/</PackageOutputPath>
+		<PackageOutputPath>../../build/</PackageOutputPath>
     <PackageVersion>$(BuildVersion)</PackageVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>false</IncludeSource>

--- a/src/Castle.Facilities.EventWiring/Castle.Facilities.EventWiring-VS2017.csproj
+++ b/src/Castle.Facilities.EventWiring/Castle.Facilities.EventWiring-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>

--- a/src/Castle.Facilities.FactorySupport/Castle.Facilities.FactorySupport-VS2017.csproj
+++ b/src/Castle.Facilities.FactorySupport/Castle.Facilities.FactorySupport-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>

--- a/src/Castle.Facilities.Logging/Castle.Facilities.Logging-VS2017.csproj
+++ b/src/Castle.Facilities.Logging/Castle.Facilities.Logging-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>

--- a/src/Castle.Facilities.Synchronize/Castle.Facilities.Synchronize-VS2017.csproj
+++ b/src/Castle.Facilities.Synchronize/Castle.Facilities.Synchronize-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>

--- a/src/Castle.Facilities.WcfIntegration/Castle.Facilities.WcfIntegration-VS2017.csproj
+++ b/src/Castle.Facilities.WcfIntegration/Castle.Facilities.WcfIntegration-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>

--- a/src/Castle.Windsor/Castle.Windsor-VS2017.csproj
+++ b/src/Castle.Windsor/Castle.Windsor-VS2017.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props"></Import>
+  <Import Project="..\..\buildscripts\common.props"></Import>
 
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>


### PR DESCRIPTION
Harmonised the look and feel of the solution with Castle Core, great to have things looking the same. Also moved build output to .\build in keeping with old build conventions. common.props lives in buildscripts for core so moved this across also. Made sure the build versions also behave similarly to castle core, local builds always have 0.0.0