### PR TITLE
Use ThreadStaticAtribute instead of Thread.AllocateDataSlot()

### DIFF
--- a/src/Castle.Windsor/MicroKernel/SubSystems/Conversion/DefaultConversionManager.cs
+++ b/src/Castle.Windsor/MicroKernel/SubSystems/Conversion/DefaultConversionManager.cs
@@ -16,7 +16,6 @@ namespace Castle.MicroKernel.SubSystems.Conversion
 {
 	using System;
 	using System.Collections.Generic;
-	using System.Threading;
 
 	using Castle.Core;
 	using Castle.Core.Configuration;
@@ -28,12 +27,8 @@ namespace Castle.MicroKernel.SubSystems.Conversion
 	[Serializable]
 	public class DefaultConversionManager : AbstractSubSystem, IConversionManager, ITypeConverterContext
 	{
-#if (!SILVERLIGHT)
-		private static readonly LocalDataStoreSlot slot = Thread.AllocateDataSlot();
-#else
 		[ThreadStatic]
 		private static Stack<Pair<ComponentModel,CreationContext>> slot;
-#endif
 		private readonly IList<ITypeConverter> converters = new List<ITypeConverter>();
 		private readonly IList<ITypeConverter> standAloneConverters = new List<ITypeConverter>();
 
@@ -197,24 +192,12 @@ namespace Castle.MicroKernel.SubSystems.Conversion
 		{
 			get
 			{
-#if (SILVERLIGHT)
-				if(slot == null)
+				if (slot == null)
 				{
-					slot = new Stack<Pair<ComponentModel,CreationContext>>();
+					slot = new Stack<Pair<ComponentModel, CreationContext>>();
 				}
 
 				return slot;
-#else
-				var stack = (Stack<Pair<ComponentModel, CreationContext>>)Thread.GetData(slot);
-				if (stack == null)
-				{
-					stack = new Stack<Pair<ComponentModel, CreationContext>>();
-					Thread.SetData(slot, stack);
-				}
-
-				return stack;
-
-#endif
 			}
 		}
 	}


### PR DESCRIPTION
Use `ThreadStaticAtribute` instead of `Thread.AllocateDataSlot()`. `ThreadStaticAttribute` is the recommended option https://msdn.microsoft.com/en-us/library/system.threading.thread.allocatedataslot(v=vs.110).aspx