### PR TITLE
Added package restore for buildscripts.csproj, outside of VS this was…

### DIFF
--- a/buildscripts/build.cmd
+++ b/buildscripts/build.cmd
@@ -26,6 +26,7 @@ SET Configuration=Release
 GOTO restore_packages
 
 :restore_packages
+dotnet restore ./buildscripts/BuildScripts.csproj
 dotnet restore ./src/Castle.Windsor/Castle.Windsor.csproj
 dotnet restore ./src/Castle.Facilities.EventWiring/Castle.Facilities.EventWiring.csproj
 dotnet restore ./src/Castle.Facilities.FactorySupport/Castle.Facilities.FactorySupport.csproj


### PR DESCRIPTION
… causing builds to fail because it was not generating compilation artefacts that VS was secretly doing in the background