### PR TITLE
Reinstating ServiceCatalog test

### DIFF
--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
@@ -945,7 +945,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 			}
 		}
 
-		[Test, Ignore("There is a problem making this test pass locally but it passes on appveyor???")]
+		[Test]
 		public void WillRegisterServiceWithServiceCatalog()
 		{
 			var netBinding = new NetTcpBinding { PortSharingEnabled = true };

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
@@ -945,7 +945,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 			}
 		}
 
-		[Test]
+		[Test] // If you have jetbrains dotmemory installed this test might fail, it picks up another endpoint
 		public void WillRegisterServiceWithServiceCatalog()
 		{
 			var netBinding = new NetTcpBinding { PortSharingEnabled = true };


### PR DESCRIPTION
DotMemory was interfering with the endpoint discovery on my machine.  