### PR TITLE
Add comment to DefaultLifetimeScope about thread safety

### DIFF
--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -40,7 +40,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Content Include="..\..\BreakingChanges.txt" />
 		<Content Include="..\..\CHANGELOG.MD" />
 		<Content Include="..\..\LICENSE">
 			<PackagePath></PackagePath>

--- a/src/Castle.Windsor/MicroKernel/Lifestyle/Scoped/CallContextLifetimeScope.cs
+++ b/src/Castle.Windsor/MicroKernel/Lifestyle/Scoped/CallContextLifetimeScope.cs
@@ -29,8 +29,7 @@ namespace Castle.MicroKernel.Lifestyle.Scoped
 	using Castle.Windsor;
 
 	/// <summary>
-	///   Provides explicit lifetime scoping within logical path of execution. Used for types with <see
-	///    cref="LifestyleType.Scoped" /> .
+	///   Provides explicit lifetime scoping within logical path of execution. Used for types with <see cref="LifestyleType.Scoped" />.
 	/// </summary>
 	/// <remarks>
 	///   The scope is passed on to child threads, including ThreadPool threads. The capability is limited to single
@@ -53,7 +52,6 @@ namespace Castle.MicroKernel.Lifestyle.Scoped
 
 		public CallContextLifetimeScope(IKernel container) : this()
 		{
-
 		}
 
 		public CallContextLifetimeScope()

--- a/src/Castle.Windsor/MicroKernel/Lifestyle/Scoped/CallContextLifetimeScope.cs
+++ b/src/Castle.Windsor/MicroKernel/Lifestyle/Scoped/CallContextLifetimeScope.cs
@@ -44,7 +44,7 @@ namespace Castle.MicroKernel.Lifestyle.Scoped
 #if FEATURE_REMOTING
 		private static readonly string keyInCallContext = "castle.lifetime-scope-" + AppDomain.CurrentDomain.Id.ToString(CultureInfo.InvariantCulture);
 #else
-		private static readonly AsyncLocal<Guid> CallContextData = new AsyncLocal<Guid>();
+		private static readonly AsyncLocal<Guid> asyncLocal = new AsyncLocal<Guid>();
 #endif
 		private readonly Guid contextId;
 		private readonly Lock @lock = Lock.Create();
@@ -123,7 +123,7 @@ namespace Castle.MicroKernel.Lifestyle.Scoped
 #if FEATURE_REMOTING
 			CallContext.LogicalSetData(keyInCallContext, lifetimeScope.contextId);
 #else
-			CallContextData.Value = lifetimeScope.contextId;
+			asyncLocal.Value = lifetimeScope.contextId;
 #endif
 		}
 
@@ -133,7 +133,7 @@ namespace Castle.MicroKernel.Lifestyle.Scoped
 #if FEATURE_REMOTING
 			var scopeKey = CallContext.LogicalGetData(keyInCallContext);
 #else
-			var scopeKey = CallContextData.Value;
+			var scopeKey = asyncLocal.Value;
 #endif
 			if (scopeKey == null)
 			{

--- a/src/Castle.Windsor/MicroKernel/Lifestyle/Scoped/DefaultLifetimeScope.cs
+++ b/src/Castle.Windsor/MicroKernel/Lifestyle/Scoped/DefaultLifetimeScope.cs
@@ -18,6 +18,9 @@ namespace Castle.MicroKernel.Lifestyle.Scoped
 
 	using Castle.Core;
 
+	/// <remarks>
+	/// This class is not thread safe like CallContextLifetimeScope.
+	/// </remarks>
 	public class DefaultLifetimeScope : ILifetimeScope
 	{
 		private static readonly Action<Burden> emptyOnAfterCreated = delegate { };


### PR DESCRIPTION
... and a few other minor changes.

I suspect we'll probably end up merging CallContextLifetimeScope into DefaultLifetimeScope since most apps care about async now.