### PR TITLE
Fix disposal of faulted WCF client channels

### DIFF
--- a/src/Castle.Facilities.WcfIntegration/Client/WcfClientActivator.cs
+++ b/src/Castle.Facilities.WcfIntegration/Client/WcfClientActivator.cs
@@ -59,10 +59,12 @@ namespace Castle.Facilities.WcfIntegration
 
 		protected override void ApplyDecommissionConcerns(object instance)
 		{
-			base.ApplyDecommissionConcerns(instance);
-
+			// WCF channels have a _peculiar_ IDisposable implementation, which will throw if the channel is not closed gracefully.
+			// IWcfChannelHolder knows how to close/abort the channel properly, so it needs to be invoked first.
 			var channelHolder = (IWcfChannelHolder)instance;
 			channelHolder.Dispose();
+
+			base.ApplyDecommissionConcerns(instance);
 		}
 
 		protected override object Instantiate(CreationContext context)


### PR DESCRIPTION
Fix WCF client channel cleanup in WcfFacility, so that WCF channels are appropriately closed/aborted before being disposed. Otherwise, broken channels may cause exceptions to be thrown during container or scope disposal.

Fixes GH-71 and GH-104.