### PR TITLE
Fix warnings regarding non-existent package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Windsor Changelog
 
+## Unreleased
+
+Bugfixes:
+- Fix warnings regarding non-existant System.ComponentModel.TypeConverter NuGet package by updating minimum Castle Core version to 4.1.0 (#321)
+
 ## 4.0.0 (2017-07-12)
 
 Breaking Changes:

--- a/src/Castle.Facilities.WcfIntegration.Demo/Castle.Facilities.WcfIntegration.Demo.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Demo/Castle.Facilities.WcfIntegration.Demo.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core-log4net" Version="4.0.0" />
+		<PackageReference Include="Castle.Core-log4net" Version="4.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.0.0" />
-		<PackageReference Include="Castle.Core-log4net" Version="4.0.0" />
+		<PackageReference Include="Castle.Core" Version="4.1.0" />
+		<PackageReference Include="Castle.Core-log4net" Version="4.1.0" />
 		<PackageReference Include="NUnit" Version="3.6.1" />
 		<PackageReference Include="NUnit.Console" Version="3.6.1" />
 	</ItemGroup>

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -58,8 +58,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">
-		<PackageReference Include="Castle.Core-log4net" Version="4.0.0" />
-		<PackageReference Include="Castle.Core-NLog" Version="4.0.0" />
+		<PackageReference Include="Castle.Core-log4net" Version="4.1.0" />
+		<PackageReference Include="Castle.Core-NLog" Version="4.1.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/src/Castle.Windsor/Castle.Windsor.csproj
+++ b/src/Castle.Windsor/Castle.Windsor.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.0.0" />
+		<PackageReference Include="Castle.Core" Version="4.1.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">


### PR DESCRIPTION
Update minimum Castle Core version to 4.1.0 to fix package restore
warnings that turn into errors (resulting in build failure) because the
version of System.ComponentModel.TypeConverter referenced by Castle
Core does not exist.

Fixes #321