### PR TITLE
Deprecate Logging Facility's LoggerImplementation enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 Bugfixes:
 - Fix warnings regarding non-existent System.ComponentModel.TypeConverter NuGet package by updating minimum Castle Core version to 4.1.0 (#321)
 - Fix disposal of faulted WCF client channels (@jberezanski, #322)
-- Ignore minor/patch level version for AssemblyVersionAttribute as this creates binding errors for downstream libraries (@fir3pho3nixx, Core/#288)
-- Fixing master build to use Castle.Core(loggers et al) 4.1.1 (@fir3pho3nixx, #321, #326)
+- Fix binding errors because assembly version had too much detail, assembly version is now x.0.0.0 (@fir3pho3nixx, #329)
+- Update Castle Core to 4.1.1 (TODO: update again) to resolve assembly version problems because Castle Core also had too much detail
+
+Deprecations:
+- Logging Facility's `LoggerImplementation` enum, `UseLog4Net` and `UseNLog` methods are deprecated in favour of `LogUsing<T>`, this includes the `loggingApi` property for XML configuration (@jonorossi, #327)
 
 ## 4.0.0 (2017-07-12)
 

--- a/docs/logging-facility.md
+++ b/docs/logging-facility.md
@@ -9,19 +9,11 @@ The logging facility provides a seamless way to add logging capabilities to your
 
 ## Loggers
 
-You can use the following loggers implementations:
-
-Logger name | Description | Notes
------------ | ----------- | -----
-log4net | [Apache log4net](http://logging.apache.org/log4net/) | requires `Castle.Services.Logging.Log4netIntegration.dll`
-NLog | [NLog](http://nlog-project.org/) (version 2.0) | requires `Castle.Services.Logging.NLogIntegration.dll`
-Serilog | [Serilog](http://serilog.net/) (version 1.3.33) | requires `Castle.Services.Logging.SerilogIntegration.dll`
-ConsoleLogger |  |
-DiagnosticsLogger |  | 
-StreamLogger |  |
-NullLogger |   | used as placeholder
+Castle Core [provides many logger abstraction implementations](https://github.com/castleproject/Core/blob/master/docs/logging.md), however you can also create your own.
 
 ## Registering the facility
+
+:warning: **`LoggerImplementation` enum and the `loggingApi` XML property are deprecated:** Usage of `LogUsing` and `customLoggerFactory` are highly recommended even for Castle Core provided implementations.
 
 ### Via XML Configuration
 
@@ -55,10 +47,10 @@ For example to use log4net with logger configuration stored in `log4net.xml` fil
 ### In code
 
 Recommended way of configuring the facility however, is using code. The facility exposes the same options like via XML.
-For example the same configuration for log4net as above, from code would like like this.
+For example the same configuration for log4net as above, from code would look like this:
 
 ```csharp
-container.AddFacility<LoggingFacility>(f => f.LogUsing(LoggerImplementation.Log4net).WithConfig("log4net.xml"));
+container.AddFacility<LoggingFacility>(f => f.LogUsing<Log4netFactory>().WithConfig("log4net.xml"));
 ```
 
 When specifying custom `ILoggerFactory` or `IExtendedLoggerFactory` you use the following generic overload:

--- a/src/Castle.Facilities.Logging/LoggerImplementation.cs
+++ b/src/Castle.Facilities.Logging/LoggerImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
 
 namespace Castle.Facilities.Logging
 {
+	using System;
+
 	using Castle.Core.Logging;
 
 	/// <summary>
-	///   The supported <see cref = "ILogger" /> implementations
+	///   The supported <see cref = "ILoggerFactory" /> implementations.
 	/// </summary>
+	[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 	public enum LoggerImplementation
 	{
 		Custom,

--- a/src/Castle.Facilities.Logging/LoggerResolver.cs
+++ b/src/Castle.Facilities.Logging/LoggerResolver.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Facilities.Logging/LoggingFacility.cs
+++ b/src/Castle.Facilities.Logging/LoggingFacility.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2014 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#pragma warning disable CS0618 // Suppress LoggerImplementation is obsolete warning until removed
 
 namespace Castle.Facilities.Logging
 {
@@ -74,6 +76,7 @@ namespace Castle.Facilities.Logging
 		///   Initializes a new instance of the <see cref="LoggingFacility" /> class.
 		/// </summary>
 		/// <param name="loggingApi"> The LoggerImplementation that should be used </param>
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility(LoggerImplementation loggingApi) : this(loggingApi, null)
 		{
 		}
@@ -83,6 +86,7 @@ namespace Castle.Facilities.Logging
 		/// </summary>
 		/// <param name="loggingApi"> The LoggerImplementation that should be used </param>
 		/// <param name="configFile"> The configuration file that should be used by the chosen LoggerImplementation </param>
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility(LoggerImplementation loggingApi, string configFile) : this(loggingApi, null, configFile)
 		{
 		}
@@ -103,6 +107,7 @@ namespace Castle.Facilities.Logging
 		/// <param name="loggingApi"> The LoggerImplementation that should be used </param>
 		/// <param name="configFile"> The configuration file that should be used by the chosen LoggerImplementation </param>
 		/// <param name="customLoggerFactory"> The type name of the type of the custom logger factory. (only used when loggingApi is set to LoggerImplementation.Custom) </param>
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility(LoggerImplementation loggingApi, string customLoggerFactory, string configFile)
 		{
 			loggerImplementation = loggingApi;
@@ -110,27 +115,30 @@ namespace Castle.Facilities.Logging
 			configFileName = configFile;
 		}
 
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility LogUsing(LoggerImplementation loggingApi)
 		{
 			if (loggingApi == LoggerImplementation.Custom)
 			{
-				throw new FacilityException("To use custom logger use LogUsing<TCUstomLoggerFactory>() method.");
+				throw new FacilityException("To use custom logger use LogUsing<TLoggerFactory>() method.");
 			}
 			loggerImplementation = loggingApi;
 			return this;
 		}
 
-		public LoggingFacility LogUsing<TCustomLoggerFactory>() where TCustomLoggerFactory : ILoggerFactory
+		public LoggingFacility LogUsing<TLoggerFactory>()
+			where TLoggerFactory : ILoggerFactory
 		{
 			loggerImplementation = LoggerImplementation.Custom;
-			loggingFactoryType = typeof(TCustomLoggerFactory);
+			loggingFactoryType = typeof(TLoggerFactory);
 			return this;
 		}
 
-		public LoggingFacility LogUsing<TCustomLoggerFactory>(TCustomLoggerFactory loggerFactory) where TCustomLoggerFactory : ILoggerFactory
+		public LoggingFacility LogUsing<TLoggerFactory>(TLoggerFactory loggerFactory)
+			where TLoggerFactory : ILoggerFactory
 		{
 			loggerImplementation = LoggerImplementation.Custom;
-			loggingFactoryType = typeof(TCustomLoggerFactory);
+			loggingFactoryType = typeof(TLoggerFactory);
 			this.loggerFactory = loggerFactory;
 			return this;
 		}
@@ -143,10 +151,7 @@ namespace Castle.Facilities.Logging
 
 		public LoggingFacility WithConfig(string configFile)
 		{
-			if (configFile == null)
-			{
-				throw new ArgumentNullException("configFile");
-			}
+			if (configFile == null) throw new ArgumentNullException("configFile");
 
 			configFileName = configFile;
 			return this;
@@ -165,21 +170,25 @@ namespace Castle.Facilities.Logging
 		}
 
 #if CASTLE_SERVICES_LOGGING
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility UseLog4Net()
 		{
 			return LogUsing(LoggerImplementation.Log4net);
 		}
 
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility UseLog4Net(string configFile)
 		{
 			return UseLog4Net().WithConfig(configFile);
 		}
 
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility UseNLog()
 		{
 			return LogUsing(LoggerImplementation.NLog);
 		}
 
+		[Obsolete("A logger factory implementation type should be provided via LogUsing<T>(), this will be removed in the future.")]
 		public LoggingFacility UseNLog(string configFile)
 		{
 			return LogUsing(LoggerImplementation.NLog).WithConfig(configFile);
@@ -445,3 +454,5 @@ namespace Castle.Facilities.Logging
 		}
 	}
 }
+
+#pragma warning restore CS0618 // Suppress LoggerImplementation is obsolete warning until removed

--- a/src/Castle.Facilities.WcfIntegration.Tests/Client/WcfClientFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Client/WcfClientFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using Castle.Facilities.WcfIntegration.Tests.Components;
 	using Castle.MicroKernel.Facilities;
 	using Castle.MicroKernel.Registration;
+	using Castle.Services.Logging.Log4netIntegration;
 	using Castle.Windsor;
 	using Castle.Windsor.Installer;
 	using log4net.Appender;
@@ -2122,7 +2123,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 		protected void RegisterLoggingFacility(IWindsorContainer container)
 		{
-			var logging = new LoggingFacility(LoggerImplementation.ExtendedLog4net);
+			var logging = new LoggingFacility().LogUsing<ExtendedLog4netFactory>();
 			container.AddFacility(logging);
 
 			memoryAppender = new MemoryAppender();

--- a/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Service/ServiceHostFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@ namespace Castle.Facilities.WcfIntegration.Tests
 	using System.ServiceModel.Activation;
 	using System.ServiceModel.Description;
 	using System.ServiceModel.Discovery;
+
 	using Castle.Core.Resource;
 	using Castle.Facilities.Logging;
 	using Castle.Facilities.WcfIntegration.Behaviors;
 	using Castle.Facilities.WcfIntegration.Demo;
 	using Castle.Facilities.WcfIntegration.Tests.Behaviors;
+	using Castle.Services.Logging.Log4netIntegration;
 	using Castle.MicroKernel.Registration;
 	using Castle.Windsor;
 	using Castle.Windsor.Installer;
@@ -1019,7 +1021,7 @@ namespace Castle.Facilities.WcfIntegration.Tests
 
 		protected IWindsorContainer RegisterLoggingFacility(IWindsorContainer container)
 		{
-			var logging = new LoggingFacility(LoggerImplementation.ExtendedLog4net);
+			var logging = new LoggingFacility().LogUsing<ExtendedLog4netFactory>();
 			container.AddFacility(logging);
 
 			memoryAppender = new MemoryAppender();

--- a/src/Castle.Windsor.Tests/LoggingFacility/ConsoleFacilityTestCase.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/ConsoleFacilityTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2009 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@ namespace Castle.Facilities.Logging.Tests
 {
 	using System;
 	using System.IO;
+
+	using Castle.Core.Logging;
 	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
 	using Castle.Windsor;
@@ -31,7 +33,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.Console);
+			container = base.CreateConfiguredContainer<ConsoleFactory>();
 
 			outWriter.GetStringBuilder().Length = 0;
 			errorWriter.GetStringBuilder().Length = 0;

--- a/src/Castle.Windsor.Tests/LoggingFacility/ConsoleLoggerTestCase.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/ConsoleLoggerTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ namespace CastleTests.LoggingFacility
 		[Bug("FACILITIES-153")]
 		public void Can_specify_level_at_registration_time()
 		{
-			Container.AddFacility<LoggingFacility>(f => f.LogUsing(LoggerImplementation.Console).WithLevel(LoggerLevel.Fatal));
+			Container.AddFacility<LoggingFacility>(f => f.LogUsing<ConsoleFactory>().WithLevel(LoggerLevel.Fatal));
 			Container.Register(Component.For<SimpleLoggingComponent>());
 
 			var item = Container.Resolve<SimpleLoggingComponent>();

--- a/src/Castle.Windsor.Tests/LoggingFacility/ExtendedLog4NetFacilityTestCase.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/ExtendedLog4NetFacilityTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2009 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ namespace Castle.Facilities.Logging.Tests
 {
 	using System;
 	using System.IO;
+
 	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
+	using Castle.Services.Logging.Log4netIntegration;
 	using Castle.Windsor;
 	using log4net;
 	using log4net.Appender;
@@ -37,7 +39,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.ExtendedLog4net);
+			container = base.CreateConfiguredContainer<ExtendedLog4netFactory>();
 		}
 
 		[TearDown]

--- a/src/Castle.Windsor.Tests/LoggingFacility/ExtendedNLogFacilityTests.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/ExtendedNLogFacilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2009 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ namespace Castle.Facilities.Logging.Tests
 
 	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
+	using Castle.Services.Logging.NLogIntegration;
 	using Castle.Windsor;
-
 	using NLog.Targets;
 	using NUnit.Framework;
 
@@ -32,7 +32,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.ExtendedNLog);
+			container = base.CreateConfiguredContainer<ExtendedNLogFactory>();
 		}
 
 		[TearDown]

--- a/src/Castle.Windsor.Tests/LoggingFacility/Log4NetFacilityLognameOverrideTests.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/Log4NetFacilityLognameOverrideTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2012 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ namespace Castle.Facilities.Logging.Tests
 
 	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
+	using Castle.Services.Logging.Log4netIntegration;
 	using Castle.Windsor;
 
 	using NUnit.Framework;
@@ -35,7 +36,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.ExtendedLog4net, string.Empty, "Override");
+			container = base.CreateConfiguredContainer<ExtendedLog4netFactory>("Override");
 		}
 
 		[TearDown]

--- a/src/Castle.Windsor.Tests/LoggingFacility/Log4NetFacilityTests.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/Log4NetFacilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2009 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ namespace Castle.Facilities.Logging.Tests
 {
 	using System;
 	using System.IO;
+
 	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
+	using Castle.Services.Logging.Log4netIntegration;
 	using Castle.Windsor;
 	using log4net;
 	using log4net.Appender;
@@ -37,7 +39,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.ExtendedLog4net);
+			container = base.CreateConfiguredContainer<ExtendedLog4netFactory>();
 		}
 
 		[TearDown]

--- a/src/Castle.Windsor.Tests/LoggingFacility/NLogFacilityTests.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/NLogFacilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ namespace Castle.Facilities.Logging.Tests
 
 	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
+	using Castle.Services.Logging.NLogIntegration;
 	using Castle.Windsor;
 
 	using NLog;
@@ -35,7 +36,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.NLog);
+			container = base.CreateConfiguredContainer<NLogFactory>();
 		}
 
 		[TearDown]

--- a/src/Castle.Windsor.Tests/LoggingFacility/NullFacilityTest.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/NullFacilityTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2009 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,10 @@
 
 namespace Castle.Facilities.Logging.Tests
 {
-    using System;
-
-    using Castle.Facilities.Logging.Tests.Classes;
-    using Castle.MicroKernel.Registration;
-    using Castle.Windsor;
+	using Castle.Core.Logging;
+	using Castle.Facilities.Logging.Tests.Classes;
+	using Castle.MicroKernel.Registration;
+	using Castle.Windsor;
 	using NUnit.Framework;
 
 	/// <summary>
@@ -32,7 +31,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.Null);
+			container = base.CreateConfiguredContainer<NullLogFactory>();
 		}
 
 		[TearDown]

--- a/src/Castle.Windsor.Tests/LoggingFacility/OverrideLoggerTest.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/OverrideLoggerTest.cs
@@ -1,21 +1,34 @@
-﻿namespace Castle.Facilities.Logging.Tests
-{
-	using System;
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+namespace Castle.Facilities.Logging.Tests
+{
+	using Castle.Core.Logging;
 	using Castle.MicroKernel.SubSystems.Configuration;
 	using Castle.Windsor;
 
 	public abstract class OverrideLoggerTest : BaseTest
-	{		
-		protected virtual IWindsorContainer CreateConfiguredContainer(LoggerImplementation loggerApi, String custom, string logName)
+	{
+		protected virtual IWindsorContainer CreateConfiguredContainer<TLoggerFactory>(string logName)
+			where TLoggerFactory : ILoggerFactory
 		{
 			IWindsorContainer container = new WindsorContainer(new DefaultConfigurationStore());
-			var configFile = GetConfigFile(loggerApi);
+			var configFile = GetConfigFile<TLoggerFactory>();
 
-			container.AddFacility<LoggingFacility>(f => f.LogUsing(loggerApi).WithConfig(configFile).ToLog(logName));
+			container.AddFacility<LoggingFacility>(f => f.LogUsing<TLoggerFactory>().WithConfig(configFile).ToLog(logName));
 
 			return container;
 		}
-
 	}
 }

--- a/src/Castle.Windsor.Tests/LoggingFacility/TraceFacilityTest.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/TraceFacilityTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,9 +19,10 @@ namespace Castle.Facilities.Logging.Tests
 	using System.Diagnostics;
 	using System.IO;
 
+	using Castle.Core.Logging;
+	using Castle.Facilities.Logging.Tests.Classes;
 	using Castle.MicroKernel.Registration;
 	using Castle.Windsor;
-	using Castle.Facilities.Logging.Tests.Classes;
 
 	using NUnit.Framework;
 
@@ -31,7 +32,7 @@ namespace Castle.Facilities.Logging.Tests
 		[SetUp]
 		public void Setup()
 		{
-			container = base.CreateConfiguredContainer(LoggerImplementation.Trace);
+			container = base.CreateConfiguredContainer<TraceLoggerFactory>();
 			consoleWriter.GetStringBuilder().Length = 0;
 
 			var source = new TraceSource("Default");


### PR DESCRIPTION
This deprecation also includes UseLog4Net, UseNLog and the loggingApi
XML property. This is designed to simplify the logging facility to
remove something it shouldn't have to care about, consumers should
directly use LogUsing<T> and specify the factory from Castle Core or
elsewhere. These deprecated members will be removed in the next major
release.

Relates to #327.