### PR TITLE
ObjectDisposedException from singleton factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Windsor Changelog
 
+## Unreleased
+
+Bugfixes:
+- Fix TypedFactory singletons that are getting disposed by typed factory transients (@fir3pho3nixx, #61)
+
 ## 4.1.0 (2017-09-28)
 
 Bugfixes:

--- a/src/Castle.Windsor/Facilities/TypedFactory/Internal/TypedFactoryInterceptor.cs
+++ b/src/Castle.Windsor/Facilities/TypedFactory/Internal/TypedFactoryInterceptor.cs
@@ -22,13 +22,16 @@ namespace Castle.Facilities.TypedFactory.Internal
 	using Castle.Core.Interceptor;
 	using Castle.DynamicProxy;
 	using Castle.MicroKernel;
+	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Facilities;
+	using Castle.MicroKernel.Handlers;
 
 	[Transient]
 	public class TypedFactoryInterceptor : IInterceptor, IOnBehalfAware, IDisposable
 	{
 		private readonly IKernelInternal kernel;
 		private readonly IReleasePolicy scope;
+		private CreationContext creationContext = null;
 
 		private bool disposed;
 		private IDictionary<MethodInfo, FactoryMethod> methods;
@@ -44,6 +47,9 @@ namespace Castle.Facilities.TypedFactory.Internal
 
 		public void Dispose()
 		{
+			if (creationContext.GetLifestyleType() == LifestyleType.Singleton)
+				return;
+
 			disposed = true;
 			scope.Dispose();
 		}

--- a/src/Castle.Windsor/MicroKernel/Burden.cs
+++ b/src/Castle.Windsor/MicroKernel/Burden.cs
@@ -29,6 +29,8 @@ namespace Castle.MicroKernel
 
 		private List<Burden> dependencies;
 
+		public List<Burden> Dependencies => dependencies;
+
 		internal Burden(IHandler handler, bool requiresDecommission, bool trackedExternally)
 		{
 			this.handler = handler;

--- a/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
+++ b/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
@@ -15,6 +15,7 @@
 namespace Castle.MicroKernel.ComponentActivator
 {
 	using System;
+	using System.Linq;
 	using System.Reflection;
 	using System.Runtime.Serialization;
 	using System.Security;
@@ -129,6 +130,8 @@ namespace Castle.MicroKernel.ComponentActivator
 					throw new ComponentActivatorException("ComponentActivator: could not proxy " + Model.Implementation.FullName, ex, Model);
 				}
 			}
+
+			context.ApplyTo(instance);
 
 			return instance;
 		}

--- a/src/Castle.Windsor/MicroKernel/Context/CreationContextExtensions.cs
+++ b/src/Castle.Windsor/MicroKernel/Context/CreationContextExtensions.cs
@@ -1,0 +1,62 @@
+// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.MicroKernel.Context
+{
+	using System.Linq;
+	using System.Reflection;
+
+	using Castle.Core;
+	using Castle.MicroKernel.Handlers;
+
+	public static class CreationContextExtensions
+	{
+		public static void ApplyTo(this CreationContext context, object instance)
+		{
+			// We need to inject this to minimise the madness around all the custom extensions of castle windsor in facilities, 
+			// this is mainly for typed factories for now but I hope that I can start reducing indirection and diversion from 
+			// base behaviour in the microkernel in the future. For now we need this for downstream management of lifestyles.
+			// I am really not happy about the way the ITypedFactoryComponentSelector just goes off in it's own direction. 
+			// It creates a callback spaghetti mess that is very hard to debug and almost impossible to read control flow
+			// from code. 
+
+			// I hope we can chat about this in the PR. https://github.com/castleproject/Windsor/pull/61#issuecomment-305029815
+
+			var creationContexts = instance.GetType().GetTypeInfo().GetFields(BindingFlags.Instance | BindingFlags.NonPublic).Where(x => x.FieldType == typeof(CreationContext)).ToList();
+			if (creationContexts.Any())
+			{
+				creationContexts.First().SetValue(instance, context);
+			}
+		}
+
+		public static void RemoveCreationContext(this object instance)
+		{
+			if (instance == null) return;
+			var creationContexts = instance.GetType().GetTypeInfo().GetFields(BindingFlags.Instance | BindingFlags.NonPublic).Where(x => x.FieldType == typeof(CreationContext)).ToList();
+			if (creationContexts.Any())
+			{
+				creationContexts.First().SetValue(instance, null);
+			}
+		}
+
+		public static LifestyleType GetLifestyleType(this CreationContext context)
+		{
+			if (context?.Handler is AbstractHandler)
+			{
+				return (context.Handler as AbstractHandler).ComponentModel.LifestyleType;
+			}
+			return LifestyleType.Undefined;
+		}
+	}
+}

--- a/src/Castle.Windsor/MicroKernel/Lifestyle/SingletonLifestyleManager.cs
+++ b/src/Castle.Windsor/MicroKernel/Lifestyle/SingletonLifestyleManager.cs
@@ -15,6 +15,7 @@
 namespace Castle.MicroKernel.Lifestyle
 {
 	using System;
+	using System.Collections.Generic;
 
 	using Castle.Core.Internal;
 	using Castle.MicroKernel.Context;
@@ -33,6 +34,7 @@ namespace Castle.MicroKernel.Lifestyle
 			var localInstance = cachedBurden;
 			if (localInstance != null)
 			{
+				RemoveAllCreationContexts(localInstance);
 				localInstance.Release();
 				cachedBurden = null;
 			}
@@ -70,6 +72,13 @@ namespace Castle.MicroKernel.Lifestyle
 		public object GetContextInstance(CreationContext context)
 		{
 			return context.GetContextualProperty(ComponentActivator);
+		}
+
+		private static void RemoveAllCreationContexts(Burden localInstance)
+		{
+			localInstance.Instance.RemoveCreationContext();
+			foreach (var instance in localInstance.Dependencies ?? new List<Burden>())
+				RemoveAllCreationContexts(instance);
 		}
 	}
 }


### PR DESCRIPTION
This fixes the problem of TypeFactory interfaces that are singletons then get consumed transients and are accidentally disposed on Release. They should only really be disposed when the container is disposed. The problem with this solution is that ITypedFactoryComponentSelector creates a callback spaghetti in the TypedFactory facility. This is incredibly hard to understand and is not easily fixable without refactoring a whole heap of stuff. I hope we can start using this concept to start moving toward a sane solution for lifestyle determinism/disposables and start deleting a whole heap of cruft. Burdens also do not distinguish between release and dispose, this causes downstream confusion with singletons when the container is disposed.

Hopefully fixes #61 && https://stackoverflow.com/questions/23706455/why-castle-windsors-typed-factory-registered-as-singleton-lifestyle-is-disposed