### PR TITLE
fixed bug in RequireScope

### DIFF
--- a/src/Castle.Windsor/MicroKernel/Lifestyle/LifestyleExtensions.cs
+++ b/src/Castle.Windsor/MicroKernel/Lifestyle/LifestyleExtensions.cs
@@ -31,12 +31,7 @@ namespace Castle.MicroKernel.Lifestyle
 
 		public static IDisposable RequireScope(this IKernel kernel)
 		{
-			var current = Scope.ObtainCurrentScope();
-			if (current == null)
-			{
-				return kernel.BeginScope();
-			}
-			return null;
+			return Scope.ObtainCurrentScope() ?? kernel.BeginScope();
 		}
 
 		public static IDisposable BeginScope(this IWindsorContainer container)
@@ -46,12 +41,7 @@ namespace Castle.MicroKernel.Lifestyle
 
 		public static IDisposable RequireScope(this IWindsorContainer container)
 		{
-			var current = Scope.ObtainCurrentScope();
-			if (current == null)
-			{
-				return container.BeginScope();
-			}
-			return null;
+			return Scope.ObtainCurrentScope() ?? container.BeginScope();
 		}
 	}
 }


### PR DESCRIPTION
the RequireScope method was returning null if ObtainCurrentScope returns a value which is very strange