### PR TITLE
ValidateConfiguration for ASP.NET Core facility should be renamed

### DIFF
--- a/src/Castle.Facilities.AspNetCore.Tests/AspNetCoreFacilityTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/AspNetCoreFacilityTestCase.cs
@@ -76,7 +76,7 @@ namespace Castle.Facilities.AspNetCore.Tests
 			Assert.Throws<Exception>(() =>
 			{
 				container.Register(Component.For<FakeFrameworkComponent>());
-				container.ValidateConfiguration();
+				container.AssertNoAspNetCoreRegistrations();
 			});
 		}
 

--- a/src/Castle.Facilities.AspNetCore/CastleWindsorRegistrationExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/CastleWindsorRegistrationExtensions.cs
@@ -78,15 +78,10 @@ namespace Castle.Facilities.AspNetCore
 
 		/// <summary>
 		/// Optional helpful exception to validate against types being installed into Windsor from the 'Microsoft.AspNetCore'
-		/// namespace. This guards against 'Torn Lifestyles' and 'Captive Depenencies'.
+		/// namespace. This guards against 'Torn Lifestyles' and 'Captive Dependencies' and will probably need to be extended.
 		/// </summary>
 		/// <param name="container">Windsor container</param>
-		public static void ValidateConfiguration(this IWindsorContainer container)
-		{
-			ThrowIfFrameworkComponentsAreRegistered(container);
-		}
-
-		private static void ThrowIfFrameworkComponentsAreRegistered(IWindsorContainer container)
+		public static void AssertNoAspNetCoreRegistrations(this IWindsorContainer container)
 		{
 			var handlers = container.Kernel.GetHandlers();
 			var hasAspNetCoreFrameworkRegistrations = handlers.Any(x => x.ComponentModel.Implementation.Namespace.StartsWith("Microsoft.AspNetCore"));


### PR DESCRIPTION
@jonorossi 

> I'm going to merge this pull request, but I think it would be a worthwhile fix to scope this either by changing the method name or something else.

https://github.com/castleproject/Windsor/pull/376#discussion-diff-167397697R84

I agree, the name itself implies it does way more than what it is "actually" doing. 
Changed the name to `NoAspNetCoreRegistrations`.