### PR TITLE
Removing deprecated BasedOn methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Breaking changes:
 - Removed obsolete indexer, AddComponent*, AddFacility and Resolve methods from IKernel and IWindsorContainer (@fir3pho3nixx, #338)
 - Facility XML configuration specifying an 'id' attribute will now throw, it has been ignored since v3.0 (@fir3pho3nixx, #338)
 - Removal of deprecated classes AllTypes and AllTypesOf (@fir3pho3nixx, #338)
+- Removal of deprecated BasedOn methods that reset registrations when fluently chained (@fir3pho3nixx, #338)
 
 New Features:
 - Created Castle.Facilities.AspNetCore facility to support ASP.NET Core web applications on .NET Core and .NET Framework (@fir3pho3nixx, #120)

--- a/src/Castle.Windsor.Tests/Registration/AllTypesTestCase.cs
+++ b/src/Castle.Windsor.Tests/Registration/AllTypesTestCase.cs
@@ -366,17 +366,11 @@ namespace CastleTests.Registration
 		[Test]
 		public void RegisterMultipleAssemblyTypes_BasedOn_RegisteredInContainer()
 		{
-#pragma warning disable 0618 //call to obsolete method
-			Kernel.Register(
-				Classes.FromAssembly(GetCurrentAssembly())
-					.BasedOn<ICommon>()
-					.BasedOn<ICustomer>()
-					.If(t => t.FullName.Contains("Chain"))
-					.BasedOn<DefaultTemplateEngine>()
-					.BasedOn<DefaultMailSenderService>()
-					.BasedOn<DefaultSpamServiceWithConstructor>()
-				);
-#pragma warning restore
+			Kernel.Register(Classes.FromAssembly(GetCurrentAssembly()).BasedOn<ICommon>());
+			Kernel.Register(Classes.FromAssembly(GetCurrentAssembly()).BasedOn<ICustomer>().If(t => t.FullName.Contains("Chain")));
+			Kernel.Register(Classes.FromAssembly(GetCurrentAssembly()).BasedOn<DefaultTemplateEngine>());
+			Kernel.Register(Classes.FromAssembly(GetCurrentAssembly()).BasedOn<DefaultMailSenderService>());
+			Kernel.Register(Classes.FromAssembly(GetCurrentAssembly()).BasedOn<DefaultSpamServiceWithConstructor>());
 
 			var handlers = Kernel.GetHandlers(typeof(ICommon));
 			Assert.AreEqual(0, handlers.Length);

--- a/src/Castle.Windsor/MicroKernel/Registration/BasedOnDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/BasedOnDescriptor.cs
@@ -63,30 +63,6 @@ namespace Castle.MicroKernel.Registration
 		}
 
 		/// <summary>
-		///   Returns the descriptor for accepting a new type.
-		/// </summary>
-		/// <typeparam name = "T"> The base type. </typeparam>
-		/// <returns> The descriptor for the type. </returns>
-		[Obsolete("Calling this method resets registration. If that's what you want, start anew, with Classes.FromAssembly..")]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public BasedOnDescriptor BasedOn<T>()
-		{
-			return from.BasedOn<T>();
-		}
-
-		/// <summary>
-		///   Returns the descriptor for accepting a new type.
-		/// </summary>
-		/// <param name = "basedOn"> The base type. </param>
-		/// <returns> The descriptor for the type. </returns>
-		[Obsolete("Calling this method resets registration. If that's what you want, start anew, with Classes.FromAssembly...")]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public BasedOnDescriptor BasedOn(Type basedOn)
-		{
-			return from.BasedOn(basedOn);
-		}
-
-		/// <summary>
 		///   Adds another type to be accepted as base.
 		/// </summary>
 		/// <param name = "basedOn"> The base type. </param>
@@ -186,19 +162,6 @@ namespace Castle.MicroKernel.Registration
 		{
 			this.unlessFilter += unlessFilter;
 			return this;
-		}
-
-		/// <summary>
-		///   Returns the descriptor for accepting a type based on a condition.
-		/// </summary>
-		/// <param name = "accepted"> The accepting condition. </param>
-		/// <returns> The descriptor for the type. </returns>
-		[Obsolete("Calling this method resets registration. If that's what you want, start anew, with Classes.FromAssembly..."
-			)]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public BasedOnDescriptor Where(Predicate<Type> accepted)
-		{
-			return from.Where(accepted);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR addresses the removal of BasedOn methods that reset component registrations when fluently chained from issue #338. 