### PR TITLE
ASP.NET Core Facility (made @Inject directive work)

### DIFF
--- a/docs/aspnetcore-facility.md
+++ b/docs/aspnetcore-facility.md
@@ -10,38 +10,21 @@ The ASP.NET Core facility provides Castle Windsor integration using a custom act
 
 Custom activators are injected into the ASP.NET Core framework when the `services.AddCastleWindsor(container)` extension is called
 from the `ConfigureServices(IServiceCollection services)` method in the `Startup` class. This allows components to be resolved from Windsor 
-when web requests are made to the server. 
+when web requests are made to the server for TagHelpers, ViewComponents and Controllers. 
 
-This method also adds a sub resolver for dealing with the resolution of ASP.NET Core framework 
-types. An example might be something like an [ILoggerFactory](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.iloggerfactory?view=aspnetcore-2.0).
-It is important to note that this extension also injects custom middleware for the management of scoped lifestyles. This middleware calls
-the `WindsorContainer.BeginScope` extension. It will also dispose the scope once the request is completed.
+This method also adds a sub resolver for dealing with the resolution of ASP.NET Core framework types. An example might be something like an 
+[ILoggerFactory](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.iloggerfactory?view=aspnetcore-2.0). 
+It is important to note that this extension also injects custom middleware for the management of scoped lifestyles. This middleware calls the 
+`WindsorContainer.BeginScope` extension for scoped lifestyles. It will also dispose the scope once the request is completed.
 
-`Controllers`, `ViewComponents` and `TagHelpers` are registered automatically for you when the `app.UseCastleWindsor<Startup>(container)` extension
-is called from the `Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)` method in the `Startup` class.
-Controllers are registered with a scoped lifestyle, and are assumed to be a single instance for the duration of the web request. The `ViewComponents`
-and `TagHelpers` however are transient. It is assumed that they will called multiple times for a single request and cannot share state.
+`Controllers`, `ViewComponents` and `TagHelpers` are registered automatically for you when the `services.AddCastleWindsor(container)` extension
+is called. Controllers are registered with a scoped lifestyle, and are assumed to be a single instance for the duration of the web request. 
+The `ViewComponents` and `TagHelpers` however are transient. It is assumed that they will called multiple times for a single request and cannot share state.
 If your controllers, view components or taghelpers are in a different assembly, you call this extension multiple times supplying an example
 type for which Windsor will then scan that assembly for framework types.
 
-If you would like to change the lifestyles of any of these components, then you do not call the `app.UseCastleWindsor<Startup>(container)`
-extension. You can opt for your own conventional registrations instead like so:
-
-```csharp
-container.Register(Classes.FromAssemblyInThisApplication(typeof(TStartup).Assembly)
-	.BasedOn<Controller>().LifestyleScoped()); // <- Change lifestyle
-container.Register(Classes.FromAssemblyInThisApplication(typeof(TStartup).Assembly)
-	.BasedOn<ViewComponent>().LifestyleTransient());
-container.Register(Classes.FromAssemblyInThisApplication(typeof(TStartup).Assembly)
-	.BasedOn<TagHelper>().LifestyleTransient());
-```
-
-It is also very important to note that you should never register any framework services in Windsor. This is handled by the framework for you. In the 
-case of [ILoggerFactory](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.iloggerfactory?view=aspnetcore-2.0) mentioned earlier, 
-you will notice it is not installed anywhere in the Startup.cs example below.
-
-You also have an optional extension for validating that you don't have any types installed from the 'Microsoft.AspNetCore' called `AssertNoAspNetCoreRegistrations`.
-This could optionally be called from a unit test or you can add it to your Startup to guard against this at runtime.
+It is also very important to note anything registered in Windsor will automatically become available in the IServiceCollection as a late bound component. This
+was needed to make @Inject directives work for Razor views.
 
 ## What do I need to set it up?
 
@@ -51,7 +34,7 @@ Here is a complete example:
 ```csharp
 public class Startup
 {
-	private readonly WindsorContainer container = new WindsorContainer();
+	public static readonly WindsorContainer Container = new WindsorContainer();
 
 	public Startup(IHostingEnvironment env)
 	{
@@ -71,18 +54,24 @@ public class Startup
 	{
 		// Add framework services.
 		services.AddMvc();
-		services.AddCastleWindsor(container); // <- Registers activators
+		services.AddLogging((lb) => lb.AddConsole().AddDebug());
+		services.AddSingleton<FrameworkMiddleware>(); // Do this if you don't care about using Windsor
+
+		// Castle Windsor integration, controllers, tag helpers and view components
+		services.AddCastleWindsor(Container);
+
+		// Custom application component registrations
+		RegisterApplicationComponents();
 	}
 
 	// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 	public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 	{
-		app.UseCastleWindsor<Startup>(container); // <- Registers controllers, view components and tag helpers
+		// Add custom middleware, do this if your middleware uses DI from Windsor
+		app.UseCastleWindsorMiddleware<CustomMiddleware>(Container);
 
-		RegisterApplicationComponents();
-
-		// Add custom middleware
-		app.UseCastleWindsorMiddleware<CustomMiddleware>(container);
+		// Add framework configured middleware
+		app.UseMiddleware<FrameworkMiddleware>();
 
 		app.UseStaticFiles();
 
@@ -92,23 +81,45 @@ public class Startup
 				"default",
 				"{controller=Home}/{action=Index}/{id?}");
 		});
-	
-		// Validates against aspnet core framework components being accidentally registered 
-		container.AssertNoAspNetCoreRegistrations();
 	}
 
 	private void RegisterApplicationComponents()
 	{
-		// Custom Windsor registrations
-		container.Register(Component.For<IUserService>().ImplementedBy<AspNetUserService>().LifestyleScoped());
+		// Application registrations
+		Container.Register(Component.For<IHttpContextAccessor>().ImplementedBy<HttpContextAccessor>());
+		Container.Register(Component.For<IUserService>().ImplementedBy<AspNetUserService>().LifestyleScoped());
 	}
 }
 
-public interface IUserService { }
+public interface IUserService : IDisposable
+{
+	IEnumerable<string> GetAll();
+}
 
-public class AspNetUserService : IUserService { }
+public class AspNetUserService : IUserService
+{
+	public IEnumerable<string> GetAll()
+	{
+		return new[] { "AnyUser" };
+	}
 
-// Example of some custom user-defined middleware component.
+	public void Dispose()
+	{
+	}
+}
+
+// Example of framework configured middleware component, can't consume types registered in Windsor
+public class FrameworkMiddleware : IMiddleware
+{
+	public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+	{
+		// Do something before
+		await next(context);
+		// Do something after
+	}
+}
+
+// Example of some custom user-defined middleware component. Resolves types from Windsor.
 public sealed class CustomMiddleware : IMiddleware
 {
 	private readonly IUserService userService;
@@ -129,13 +140,14 @@ public sealed class CustomMiddleware : IMiddleware
 
 ## Registering ASP.NET Core framework components in Windsor
 
-Simply put, don't do this. The instance that Windsor resolves might not always be the same instance that is resolved by the ASP.NET Core framework. If the 
-instance is stateful or is registered with a competing lifestyle this can lead to problems. 
+You can do it via the IServiceCollection or the IWindsorContainer but not both. This is because if it is registered through Windsor it automatically gets 
+registered in the IServiceCollection using a factory method which calls back to the container to resolve it. If they have been registered through the 
+IServiceCollection they are still resolvable through a sub dependency resolver for which Windsor does not activate or track instances.
 
 ### Torn lifestyles
 
 If you register a framework component as scoped in Windsor and the ASP.NET Core framework has registered it as scoped also, two instances might appear. This
-problem is further obfiscated if those objects are stateful. This is known as a `torn lifestyle`. 
+problem is further obfiscated if those objects are stateful. This is known as a `torn lifestyle`. We hope to have avoided this in this facility's design.
 
 References:
  - https://simpleinjector.readthedocs.io/en/latest/tornlifestyle.html
@@ -153,4 +165,4 @@ Special credit goes to:
  - [@dotnetjunkie](https://github.com/dotnetjunkie) for pioneering the discussions with the ASP.NET team for non-conforming containers and providing valuable input on issue: https://github.com/castleproject/Windsor/issues/120 
  - [@ploeh](https://github.com/ploeh) for defining `Captive Dependencies`: http://blog.ploeh.dk/2014/06/02/captive-dependency/
  - [@hikalkan](https://github.com/hikalkan) for implementing https://github.com/volosoft/castle-windsor-ms-adapter. 
-
+ - [@generik0](https://github.com/generik0) for discussing here: https://github.com/castleproject/Windsor/pull/389

--- a/src/Castle.Facilities.AspNetCore/Activators/DelegatingControllerActivator.cs
+++ b/src/Castle.Facilities.AspNetCore/Activators/DelegatingControllerActivator.cs
@@ -24,10 +24,12 @@ namespace Castle.Facilities.AspNetCore.Activators
 		private readonly Func<ControllerContext, object> controllerCreator;
 		private readonly Action<ControllerContext, object> controllerReleaser;
 
-		public DelegatingControllerActivator(Func<ControllerContext, object> controllerCreator, Action<ControllerContext, object> controllerReleaser = null)
+		public DelegatingControllerActivator(
+			Func<ControllerContext, object> controllerCreator, 
+			Action<ControllerContext, object> controllerReleaser)
 		{
 			this.controllerCreator = controllerCreator ?? throw new ArgumentNullException(nameof(controllerCreator));
-			this.controllerReleaser = controllerReleaser ?? ((_, __) => { });
+			this.controllerReleaser = controllerReleaser ?? throw new ArgumentNullException(nameof(controllerReleaser));
 		}
 
 		public object Create(ControllerContext context)

--- a/src/Castle.Facilities.AspNetCore/Activators/DelegatingTagHelperActivator.cs
+++ b/src/Castle.Facilities.AspNetCore/Activators/DelegatingTagHelperActivator.cs
@@ -26,7 +26,10 @@ namespace Castle.Facilities.AspNetCore.Activators
 		private readonly Func<Type, object> customTagHelperCreator;
 		private readonly ITagHelperActivator defaultTagHelperActivator;
 
-		public DelegatingTagHelperActivator(Predicate<Type> customCreatorSelector, Func<Type, object> customTagHelperCreator, ITagHelperActivator defaultTagHelperActivator)
+		public DelegatingTagHelperActivator(
+			Predicate<Type> customCreatorSelector, 
+			Func<Type, object> customTagHelperCreator, 
+			ITagHelperActivator defaultTagHelperActivator)
 		{
 			this.customCreatorSelector = customCreatorSelector ?? throw new ArgumentNullException(nameof(customCreatorSelector));
 			this.customTagHelperCreator = customTagHelperCreator ?? throw new ArgumentNullException(nameof(customTagHelperCreator));

--- a/src/Castle.Facilities.AspNetCore/Activators/DelegatingViewComponentActivator.cs
+++ b/src/Castle.Facilities.AspNetCore/Activators/DelegatingViewComponentActivator.cs
@@ -23,10 +23,10 @@ namespace Castle.Facilities.AspNetCore.Activators
 		private readonly Func<Type, object> viewComponentCreator;
 		private readonly Action<object> viewComponentReleaser;
 
-		public DelegatingViewComponentActivator(Func<Type, object> viewComponentCreator, Action<object> viewComponentReleaser = null)
+		public DelegatingViewComponentActivator(Func<Type, object> viewComponentCreator, Action<object> viewComponentReleaser)
 		{
 			this.viewComponentCreator = viewComponentCreator ?? throw new ArgumentNullException(nameof(viewComponentCreator));
-			this.viewComponentReleaser = viewComponentReleaser ?? (_ => { });
+			this.viewComponentReleaser = viewComponentReleaser ?? throw new ArgumentNullException(nameof(viewComponentReleaser));
 		}
 
 		public object Create(ViewComponentContext context)

--- a/src/Castle.Facilities.AspNetCore/AspNetCoreMvcExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/AspNetCoreMvcExtensions.cs
@@ -28,20 +28,20 @@ namespace Castle.Facilities.AspNetCore
 
 	internal static class AspNetCoreMvcExtensions
 	{
-		public static void AddCustomControllerActivation(this IServiceCollection services, Func<Type, object> activator)
+		public static void AddCustomControllerActivation(this IServiceCollection services, Func<Type, object> activator, Action<object> releaser)
 		{
 			if (services == null) throw new ArgumentNullException(nameof(services));
 			if (activator == null) throw new ArgumentNullException(nameof(activator));
 
-			services.AddSingleton<IControllerActivator>(new DelegatingControllerActivator(context => activator(context.ActionDescriptor.ControllerTypeInfo.AsType())));
+			services.AddSingleton<IControllerActivator>(new DelegatingControllerActivator(context => activator(context.ActionDescriptor.ControllerTypeInfo.AsType()), (context, instance) => releaser(instance)));
 		}
 
-		public static void AddCustomViewComponentActivation(this IServiceCollection services, Func<Type, object> activator)
+		public static void AddCustomViewComponentActivation(this IServiceCollection services, Func<Type, object> activator, Action<object> releaser)
 		{
 			if (services == null) throw new ArgumentNullException(nameof(services));
 			if (activator == null) throw new ArgumentNullException(nameof(activator));
 
-			services.AddSingleton<IViewComponentActivator>(new DelegatingViewComponentActivator(activator));
+			services.AddSingleton<IViewComponentActivator>(new DelegatingViewComponentActivator(activator, releaser));
 		}
 
 		public static void AddCustomTagHelperActivation(this IServiceCollection services, Func<Type, object> activator, Predicate<Type> applicationTypeSelector = null)

--- a/src/Castle.Facilities.AspNetCore/Resolvers/FrameworkConfigurationDependencyResolver.cs
+++ b/src/Castle.Facilities.AspNetCore/Resolvers/FrameworkConfigurationDependencyResolver.cs
@@ -26,13 +26,11 @@ namespace Castle.Facilities.AspNetCore.Resolvers
 
 	public class FrameworkConfigurationDependencyResolver : ISubDependencyResolver
 	{
-		private readonly ServiceProvider serviceProvider;
 		private readonly IServiceCollection serviceCollection;
 
 		public FrameworkConfigurationDependencyResolver(IServiceCollection serviceCollection)
 		{
 			this.serviceCollection = serviceCollection;
-			serviceProvider = serviceCollection.BuildServiceProvider();
 		}
 
 		public bool CanResolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency)
@@ -49,7 +47,7 @@ namespace Castle.Facilities.AspNetCore.Resolvers
 
 		public object Resolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency)
 		{
-			return serviceProvider.GetService(dependency.TargetType);
+			return serviceCollection.BuildServiceProvider().GetService(dependency.TargetType);
 		}
 
 		private bool HasMatchingGenericTypeDefinitions(Type dependencyType)
@@ -71,17 +69,17 @@ namespace Castle.Facilities.AspNetCore.Resolvers
 				x => x.ServiceType.GenericTypeArguments.Length > 0).ToList();
 
 			return genericTypesWithParameters.Any(
-				x => x.ServiceType.GetGenericTypeDefinition() == dependencyGenericType 
+				x => x.ServiceType.GetGenericTypeDefinition() == dependencyGenericType
 					&& x.ServiceType.GenericTypeArguments.All(
-						sy => dependencyType.GenericTypeArguments.Contains(sy) 
-							&& dependencyType.GenericTypeArguments.Length == 
+						sy => dependencyType.GenericTypeArguments.Contains(sy)
+							&& dependencyType.GenericTypeArguments.Length ==
 								x.ServiceType.GenericTypeArguments.Length));
 		}
 
 		private static bool HasMatchingGenericTypesWithoutArguments(Type dependencyGenericType, List<ServiceDescriptor> genericServiceTypes)
 		{
 			var genericTypesWithoutParameters = genericServiceTypes.Where(
-				x => x.ServiceType.GenericTypeArguments.Length == 0 
+				x => x.ServiceType.GenericTypeArguments.Length == 0
 					&& x.ImplementationType.GenericTypeArguments.Length == 0).ToList();
 
 			return genericTypesWithoutParameters.Any(


### PR DESCRIPTION
Fixed problem whereby registrations had to be doubled up between the application container and the framework container to make @Inject directives work for Razor. This was achieved by registering dependencies as factories in IServiceCollections which resolve back to the IWindsorContainer. IWindsorContainer.Kernel.ComponentRegistered was used to duplicate registrations from Windsor to the IServiceCollection during ConfigureServices(IServiceCollection services). Thanks @generik0 (#389).