### PR TITLE
Make Typeutil.ToCSharpString produce more C#-like formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Enhancements:
 - Added XML documentation to BeginScope and RequireScope lifetime extensions (@jonorossi)
 - Upgraded build to use NUnit Adapters (@fir3pho3nixx, #243)
+- Make formatting of type names with `TypeUtil.ToCSharpString` (and hence in diagnostic messages) resemble C# more closely (@stakx, #404, #406)
 
 Breaking changes:
 - Built-in System.Web support has been moved to the new Castle.Facilities.AspNet.SystemWeb facility (@fir3pho3nixx, #283)

--- a/src/Castle.Windsor.Tests/TypeUtilTestCase.cs
+++ b/src/Castle.Windsor.Tests/TypeUtilTestCase.cs
@@ -14,6 +14,8 @@
 
 namespace CastleTests
 {
+	using System;
+
 	using Castle.ClassComponents;
 	using Castle.Core.Internal;
 	using Castle.MicroKernel.Tests.ClassComponents;
@@ -55,38 +57,45 @@ namespace CastleTests
 		}
 
 		[Test]
-		public void Generic_nested_generic_typeArray_multi_dimentional_pulls_closed_generics_to_innermost_type()
+		public void Closed_generic_nested_generic_on_generic_double_type()
+		{
+			var name = typeof(GenericHasNested<A2>.NestedGeneric<Tuple<int, bool>>).ToCSharpString();
+			Assert.AreEqual("GenericHasNested<A2>.NestedGeneric<Tuple<Int32, Boolean>>", name);
+		}
+
+		[Test]
+		public void Generic_nested_generic_typeArray_multi_dimensional()
 		{
 			var name = typeof(GenericHasNested<A2>.NestedGeneric<AProp>[,,]).ToCSharpString();
-			Assert.AreEqual("GenericHasNested<·TOuter·>.NestedGeneric<A2, AProp>[,,]", name);
+			Assert.AreEqual("GenericHasNested<A2>.NestedGeneric<AProp>[,,]", name);
 		}
 
 		[Test]
-		public void Generic_nested_generic_typeArray_pulls_closed_generics_to_innermost_type()
+		public void Generic_nested_generic_typeArray()
 		{
 			var name = typeof(GenericHasNested<A2>.NestedGeneric<AProp>[]).ToCSharpString();
-			Assert.AreEqual("GenericHasNested<·TOuter·>.NestedGeneric<A2, AProp>[]", name);
+			Assert.AreEqual("GenericHasNested<A2>.NestedGeneric<AProp>[]", name);
 		}
 
 		[Test]
-		public void Generic_nested_generic_type_pulls_closed_generics_to_innermost_type()
+		public void Generic_nested_generic_type()
 		{
 			var name = typeof(GenericHasNested<A2>.NestedGeneric<AProp>).ToCSharpString();
-			Assert.AreEqual("GenericHasNested<·TOuter·>.NestedGeneric<A2, AProp>", name);
+			Assert.AreEqual("GenericHasNested<A2>.NestedGeneric<AProp>", name);
 		}
 
 		[Test]
-		public void Generic_nested_type_array_ignores_outer_generic_argument()
+		public void Generic_nested_type_array()
 		{
 			var name = typeof(GenericHasNested<A2>.Nested[]).ToCSharpString();
-			Assert.AreEqual("GenericHasNested<·TOuter·>.Nested<A2>[]", name);
+			Assert.AreEqual("GenericHasNested<A2>.Nested[]", name);
 		}
 
 		[Test]
-		public void Generic_nested_type_ignores_outer_generic_argument()
+		public void Generic_nested_type()
 		{
 			var name = typeof(GenericHasNested<A2>.Nested).ToCSharpString();
-			Assert.AreEqual("GenericHasNested<·TOuter·>.Nested<A2>", name);
+			Assert.AreEqual("GenericHasNested<A2>.Nested", name);
 		}
 
 		[Test]
@@ -121,14 +130,14 @@ namespace CastleTests
 		public void Open_generic_double_type()
 		{
 			var name = typeof(IDoubleGeneric<,>).ToCSharpString();
-			Assert.AreEqual("IDoubleGeneric<·TOne·, ·TTwo·>", name);
+			Assert.AreEqual("IDoubleGeneric<TOne, TTwo>", name);
 		}
 
 		[Test]
 		public void Open_generic_simple_type()
 		{
 			var name = typeof(GenericImpl1<>).ToCSharpString();
-			Assert.AreEqual("GenericImpl1<·T·>", name);
+			Assert.AreEqual("GenericImpl1<T>", name);
 		}
 	}
 }


### PR DESCRIPTION
This changes the way how `TypeUtil.ToCSharpString` formats certain types to a representation that looks more like C#:

* **Generic type parameters.** Those are currently surrounded with a centered dot (`·`) that noone quite seems to know what they're good for. <sup>(&dagger;)</sup> (See #406, esp. the recommendation made in https://github.com/castleproject/Windsor/pull/406#issuecomment-394178922.)

* **Nested generic types.** For example, given `Outer<bool>.Inner<char>`, it outputs `"Outer<·T·>.Inner<bool, char>"` which is likely to be confusing rather than helpful. This changes the way how such types get formatted to something more familiar to C# users: `"Outer<bool>.Inner<char>"`. (This resolves #404.)

These changes are classified in the changelog as an "enhancement". Given that there were explicit unit tests about that behavior, it's not really a bugfix, but a change. Classifying as a "breaking change" would be accurate, but given that the method's intended use case is for diagnostics, it seems somewhat over-the-top to mark it as "breaking".

<sup>(&dagger;)</sup> My personal theory about the centered dots is that they were needed to mark a placeholder, so you'd know how to apply, or "distribute", the generic type arguments from the innermost type over the outer types. Now that this distribution is done automatically, the dots aren't really needed anymore.