### PR TITLE
Registration Type in WindsorRegistrationOptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 ## Unreleased
 
 Enhancements:
-- Upgraded to Castle.Core 4.2.0 to 4.3.0. https://github.com/castleproject/Core/releases/tag/v4.3.0 (@fir3pho3nixx).
+- Created Castle.Facilities.AspNetCore facility to support ASP.NET Core web applications on .NET Core and .NET Framework (@fir3pho3nixx, #120)
+- Created Castle.Facilities.AspNet.Mvc facility to support ASP.NET MVC web applications on .NET Framework (@fir3pho3nixx, #283)
+- Created Castle.Facilities.AspNet.WebApi facility to support ASP.NET Web API IIS and self hosted applications on .NET Framework (@fir3pho3nixx, #283)
 - Added XML documentation to BeginScope and RequireScope lifetime extensions (@jonorossi)
 - Upgraded build to use NUnit Adapters (@fir3pho3nixx, #243)
 - Make formatting of type names with `TypeUtil.ToCSharpString` (and hence in diagnostic messages) resemble C# more closely (@stakx, #404, #406)
+- Upgraded Castle.Core from 4.2.0 to 4.3.0 (@fir3pho3nixx, #409)
 
-Breaking changes:
+Breaking Changes:
 - Built-in System.Web support has been moved to the new Castle.Facilities.AspNet.SystemWeb facility (@fir3pho3nixx, #283)
 - Removed obsolete ActAs, Parameters, Properties and ServiceOverrides methods from component registration (@fir3pho3nixx, #338)
 - Removed obsolete indexer, AddComponent*, AddFacility and Resolve methods from IKernel and IWindsorContainer (@fir3pho3nixx, #338)
@@ -17,11 +20,6 @@ Breaking changes:
 - Removal of deprecated BasedOn methods that reset registrations when fluently chained (@fir3pho3nixx, #338)
 - Removal of deprecated member LifestyleHandlerType on CustomLifestyleAttribute (@fir3pho3nixx, #338)
 - Removed Event Wiring, Factory Support and Synchronize facilities (@jonorossi, #403)
-
-New Features:
-- Created Castle.Facilities.AspNetCore facility to support ASP.NET Core web applications on .NET Core and .NET Framework (@fir3pho3nixx, #120)
-- Created Castle.Facilities.AspNet.Mvc facility to support ASP.NET MVC web applications on .NET Framework (@fir3pho3nixx, #283)
-- Created Castle.Facilities.AspNet.WebApi facility to support ASP.NET Web API IIS and self hosted applications on .NET Framework (@fir3pho3nixx, #283)
 
 ## 4.1.0 (2017-09-28)
 


### PR DESCRIPTION
Issues [423](https://github.com/castleproject/Windsor/issues/423)

[WindsorRegistrationOptions ](https://github.com/castleproject/Windsor/blob/master/src/Castle.Facilities.AspNetCore/WindsorRegistrationOptions.cs#L25) was meant to be the way of overriding defaults used for registration.  should expose the [component registration](https://github.com/castleproject/Windsor/blob/master/src/Castle.Windsor/MicroKernel/Registration/Component.cs#L33) api's for maximum flexibility