### PR TITLE
Deprecate Lock in favour of ReaderWriterLockSlim

### DIFF
--- a/src/Castle.Windsor/MicroKernel/Releasers/LifecycledComponentsReleasePolicy.cs
+++ b/src/Castle.Windsor/MicroKernel/Releasers/LifecycledComponentsReleasePolicy.cs
@@ -40,7 +40,7 @@ namespace Castle.MicroKernel.Releasers
 		private readonly Dictionary<object, Burden> instance2Burden =
 			new Dictionary<object, Burden>(ReferenceEqualityComparer<object>.Instance);
 
-		private readonly Lock @lock = Lock.Create();
+		private readonly ReaderWriterLockSlim @lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 		private readonly ITrackedComponentsPerformanceCounter perfCounter;
 		private ITrackedComponentsDiagnostic trackedComponentsDiagnostic;
 
@@ -84,16 +84,16 @@ namespace Castle.MicroKernel.Releasers
 		{
 			get
 			{
-				using (var holder = @lock.ForReading(false))
+				@lock.EnterReadLock();
+
+				try
 				{
-					if (holder.LockAcquired == false)
-					{
-						// TODO: that's sad... perhaps we should have waited...? But what do we do now? We're in the debugger. If some thread is keeping the lock
-						// we could wait indefinatelly. I guess the best way to proceed is to add a 200ms timepout to accquire the lock, and if not succeeded
-						// assume that the other thread just waits and is not going anywhere and go ahead and read this anyway...
-					}
 					var array = instance2Burden.Values.ToArray();
 					return array;
+				}
+				finally
+				{
+					@lock.ExitReadLock();
 				}
 			}
 		}
@@ -101,16 +101,26 @@ namespace Castle.MicroKernel.Releasers
 		public void Dispose()
 		{
 			KeyValuePair<object, Burden>[] burdens;
-			using (@lock.ForWriting())
+
+			@lock.EnterWriteLock();
+
+			try
 			{
+
 				if (trackedComponentsDiagnostic != null)
 				{
 					trackedComponentsDiagnostic.TrackedInstancesRequested -= trackedComponentsDiagnostic_TrackedInstancesRequested;
 					trackedComponentsDiagnostic = null;
 				}
+
 				burdens = instance2Burden.ToArray();
 				instance2Burden.Clear();
 			}
+			finally
+			{
+				@lock.ExitWriteLock();
+			}
+
 			// NOTE: This is relying on a undocumented behavior that order of items when enumerating Dictionary<> will be oldest --> latest
 			foreach (var burden in burdens.Reverse())
 			{
@@ -133,10 +143,17 @@ namespace Castle.MicroKernel.Releasers
 				return false;
 			}
 
-			using (@lock.ForReading())
+			@lock.EnterReadLock();
+
+			try
 			{
 				return instance2Burden.ContainsKey(instance);
 			}
+			finally
+			{
+				@lock.ExitReadLock();
+			}
+
 		}
 
 		public void Release(object instance)
@@ -147,7 +164,10 @@ namespace Castle.MicroKernel.Releasers
 			}
 
 			Burden burden;
-			using (@lock.ForWriting())
+
+			@lock.EnterWriteLock();
+
+			try
 			{
 				// NOTE: we don't physically remove the instance from the instance2Burden collection here.
 				// we do it in OnInstanceReleased event handler
@@ -156,6 +176,11 @@ namespace Castle.MicroKernel.Releasers
 					return;
 				}
 			}
+			finally
+			{
+				@lock.ExitWriteLock();
+			}
+
 			burden.Release();
 		}
 
@@ -169,12 +194,12 @@ namespace Castle.MicroKernel.Releasers
 						"Release policy was asked to track object '{0}', but its burden has 'RequiresPolicyRelease' set to false. If object is to be tracked the flag must be true. This is likely a bug in the lifetime manager '{1}'.",
 						instance, lifestyle));
 			}
+
 			try
 			{
-				using (@lock.ForWriting())
-				{
-					instance2Burden.Add(instance, burden);
-				}
+				@lock.EnterWriteLock();
+
+				instance2Burden.Add(instance, burden);
 			}
 			catch (ArgumentNullException)
 			{
@@ -185,19 +210,31 @@ namespace Castle.MicroKernel.Releasers
 			{
 				throw HelpfulExceptionsUtil.TrackInstanceCalledMultipleTimes(instance, burden);
 			}
+			finally
+			{
+				@lock.ExitWriteLock();
+			}
+
 			burden.Released += OnInstanceReleased;
 			perfCounter.IncrementTrackedInstancesCount();
 		}
 
 		private void OnInstanceReleased(Burden burden)
 		{
-			using (@lock.ForWriting())
+			try
 			{
+				@lock.EnterWriteLock();
+
 				if (instance2Burden.Remove(burden.Instance) == false)
 				{
 					return;
 				}
 			}
+			finally
+			{
+				@lock.ExitWriteLock();
+			}
+
 			burden.Released -= OnInstanceReleased;
 			perfCounter.DecrementTrackedInstancesCount();
 		}


### PR DESCRIPTION
As part of https://github.com/castleproject/Core/issues/376 the change for removing [Lock](https://github.com/castleproject/Core/pull/391/files#diff-38265397b99a6db95030e27b3f143441L26) in Castle.Core has left us wanting for new ways down here in Windsor.  

This is an experimental as per https://github.com/castleproject/Core/issues/376#issuecomment-410371303