### PR TITLE
Implemented IRegistration[] in ASP.NET Core facility WindsorRegistrationOptions

### DIFF
--- a/docs/aspnetcore-facility.md
+++ b/docs/aspnetcore-facility.md
@@ -33,6 +33,17 @@ services.AddWindsor(container, opts =>
 ```
 
 This is also useful if your framework components live in a separate assemblies or are not defined in the same assembly as your web application.
+You can also register your components with a finer grain of control by using the IRegistration[] overloads. Example below:
+
+```csharp
+services.AddWindsor(container, opts =>
+{
+	opts.RegisterControllers(Component.For<HomeController>().LifestyleTransient());
+	opts.RegisterTagHelpers(Component.For<EmailTagHelper>().LifestyleTransient());
+	opts.RegisterViewComponents(Component.For<AddressComponent>().LifestyleTransient());
+});
+```
+
 Alternatively if your framework components all live in one assembly and you dont need to change lifestyles then you can simply use the following:
 
 ```csharp

--- a/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsTestCase.cs
@@ -17,24 +17,17 @@ namespace Castle.Facilities.AspNetCore.Tests
 	using System;
 
 	using Castle.Facilities.AspNetCore.Tests.Framework;
+	using Castle.MicroKernel.Registration;
 
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Razor.TagHelpers;
 
 	using NUnit.Framework;
 
-	[TestFixture, Order(3)]
-	public class WindsorRegistrationOptionsTestCase
+	public abstract class WindsorRegistrationOptionsTestCase
 	{
 		[SetUp]
-		public void SetUp()
-		{
-			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(typeof(OverrideTagHelper).Assembly)
-				.RegisterControllers(typeof(OverrideController).Assembly)
-				.RegisterTagHelpers(typeof(OverrideViewComponent).Assembly));
-		}
+		public abstract void SetUp();
 
 		[TearDown]
 		public void TearDown()
@@ -42,7 +35,7 @@ namespace Castle.Facilities.AspNetCore.Tests
 			testContext.Dispose();
 		}
 
-		private Framework.TestContext testContext;
+		protected Framework.TestContext testContext;
 
 		[TestCase(typeof(OverrideTagHelper))]
 		[TestCase(typeof(OverrideController))]
@@ -62,6 +55,34 @@ namespace Castle.Facilities.AspNetCore.Tests
 
 		public class OverrideViewComponent : ViewComponent
 		{
+		}
+	}
+
+	[TestFixture, Order(3)]
+	public class WindsorRegistrationOptionsForAssembliesTestCase : WindsorRegistrationOptionsTestCase
+	{
+		[SetUp]
+		public override void SetUp()
+		{
+			testContext = TestContextFactory.Get(opts => opts
+				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
+				.RegisterTagHelpers(typeof(OverrideTagHelper).Assembly)
+				.RegisterControllers(typeof(OverrideController).Assembly)
+				.RegisterTagHelpers(typeof(OverrideViewComponent).Assembly));
+		}
+	}
+
+	[TestFixture, Order(3)]
+	public class WindsorRegistrationOptionsForComponentsTestCase : WindsorRegistrationOptionsTestCase
+	{
+		[SetUp]
+		public override void SetUp()
+		{
+			testContext = TestContextFactory.Get(opts => opts
+				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
+				.RegisterTagHelpers(Component.For<OverrideTagHelper>().LifestyleScoped().Named("tag-helpers"))
+				.RegisterControllers(Component.For<OverrideController>().LifestyleScoped().Named("controllers"))
+				.RegisterTagHelpers(Component.For<OverrideViewComponent>().LifestyleScoped().Named("view-components")));
 		}
 	}
 }

--- a/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
@@ -93,34 +93,55 @@ namespace Castle.Facilities.AspNetCore
 
 		private static void AddApplicationComponentsToWindsor(IWindsorContainer container, WindsorRegistrationOptions options)
 		{
-			if (!options.ControllerRegistrations.Any())
+			// Applying default registrations, Lifestyle here is Scoped
+
+			if (!options.ControllerAssemblyRegistrations.Any() && !options.ControllerComponentRegistrations.Any())
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<Controller>().LifestyleScoped());
+				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ControllerBase>().LifestyleScoped());
 			}
 
-			foreach (var controllerRegistration in options.ControllerRegistrations)
-			{
-				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<Controller>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
-			}
-
-			if (!options.TagHelperRegistrations.Any())
+			if (!options.TagHelperAssemblyRegistrations.Any() && !options.TagHelperComponentRegistrations.Any())
 			{
 				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ViewComponent>().LifestyleScoped());
 			}
 
-			foreach (var controllerRegistration in options.TagHelperRegistrations)
+			if (!options.ViewComponentAssemblyRegistrations.Any() && !options.ViewComponentComponentRegistrations.Any())
+			{
+				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ITagHelper>().LifestyleScoped());
+			}
+
+			// Assembly registrations
+
+			foreach (var controllerRegistration in options.ControllerAssemblyRegistrations)
+			{
+				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<ControllerBase>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
+			}
+
+			foreach (var controllerRegistration in options.TagHelperAssemblyRegistrations)
 			{
 				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<ViewComponent>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
 			}
 
-			if (!options.ViewComponentRegistrations.Any())
+			foreach (var controllerRegistration in options.ViewComponentAssemblyRegistrations)
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<TagHelper>().LifestyleScoped());
+				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<ITagHelper>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
 			}
 
-			foreach (var controllerRegistration in options.ViewComponentRegistrations)
+			// Component registrations
+
+			foreach (var controllerRegistration in options.ControllerComponentRegistrations)
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<TagHelper>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
+				container.Register(controllerRegistration);
+			}
+
+			foreach (var tagHelperRegistration in options.TagHelperComponentRegistrations)
+			{
+				container.Register(tagHelperRegistration);
+			}
+
+			foreach (var viewComponentRegistration in options.ViewComponentComponentRegistrations)
+			{
+				container.Register(viewComponentRegistration);
 			}
 		}
 

--- a/src/Castle.Facilities.AspNetCore/WindsorRegistrationOptions.cs
+++ b/src/Castle.Facilities.AspNetCore/WindsorRegistrationOptions.cs
@@ -18,6 +18,7 @@ namespace Castle.Facilities.AspNetCore
 	using System.Reflection;
 
 	using Castle.Core;
+	using Castle.MicroKernel.Registration;
 
 	/// <summary>
 	/// For overriding default registration and lifestyles behaviour
@@ -43,14 +44,18 @@ namespace Castle.Facilities.AspNetCore
 			}
 		}
 
-		internal List<(Assembly, LifestyleType)> ControllerRegistrations = new List<(Assembly, LifestyleType)>();
-		internal List<(Assembly, LifestyleType)> TagHelperRegistrations = new List<(Assembly, LifestyleType)>();
-		internal List<(Assembly, LifestyleType)> ViewComponentRegistrations = new List<(Assembly, LifestyleType)>();
+		internal List<(Assembly, LifestyleType)> ControllerAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
+		internal List<(Assembly, LifestyleType)> TagHelperAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
+		internal List<(Assembly, LifestyleType)> ViewComponentAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
+
+		internal List<IRegistration> ControllerComponentRegistrations = new List<IRegistration>();
+		internal List<IRegistration> TagHelperComponentRegistrations = new List<IRegistration>();
+		internal List<IRegistration> ViewComponentComponentRegistrations = new List<IRegistration>();
 
 		/// <summary>
 		/// Use this method to specify where controllers, tagHelpers and viewComponents are registered from. Use this method
 		/// if the facility starts throwing ComponentNotFoundExceptions because of problems with <see cref="Assembly.GetCallingAssembly"/>/<see cref="Assembly.GetEntryAssembly"/>.
-		/// You can optionally use <see cref="RegisterControllers"/>/<see cref="RegisterTagHelpers"/>/<see cref="RegisterViewComponents"/> if you need more fine grained
+		/// You can optionally use <see cref="RegisterControllers(Assembly, LifestyleType)"/>/<see cref="RegisterTagHelpers(Assembly, LifestyleType)"/>/<see cref="RegisterViewComponents(Assembly, LifestyleType)"/> if you need more fine grained
 		/// control for sourcing these framework components.
 		/// </summary>
 		/// <param name="entryAssembly"></param>
@@ -69,7 +74,19 @@ namespace Castle.Facilities.AspNetCore
 		/// <returns><see cref="WindsorRegistrationOptions"/> as a fluent interface</returns>
 		public WindsorRegistrationOptions RegisterControllers(Assembly controllersAssembly = null, LifestyleType lifestyleType = LifestyleType.Scoped)
 		{
-			ControllerRegistrations.Add((controllersAssembly ?? EntryAssembly, lifestyleType));
+			ControllerAssemblyRegistrations.Add((controllersAssembly ?? EntryAssembly, lifestyleType));
+			return this;
+		}
+
+		/// <summary>
+		/// Use this method for customising the registration of controllers.
+		/// </summary>
+		/// <param name="registrations"><see cref="ComponentRegistration"/> for more details</param>
+		/// <returns></returns>
+		/// <returns><see cref="WindsorRegistrationOptions"/> as a fluent interface</returns>
+		public WindsorRegistrationOptions RegisterControllers(params IRegistration[] registrations)
+		{
+			ControllerComponentRegistrations.AddRange(registrations);
 			return this;
 		}
 
@@ -81,7 +98,19 @@ namespace Castle.Facilities.AspNetCore
 		/// <returns><see cref="WindsorRegistrationOptions"/> as a fluent interface</returns>
 		public WindsorRegistrationOptions RegisterTagHelpers(Assembly tagHelpersAssembly = null, LifestyleType lifestyleType = LifestyleType.Scoped)
 		{
-			TagHelperRegistrations.Add((tagHelpersAssembly ?? EntryAssembly, lifestyleType));
+			TagHelperAssemblyRegistrations.Add((tagHelpersAssembly ?? EntryAssembly, lifestyleType));
+			return this;
+		}
+
+		/// <summary>
+		/// Use this method for customising the registration of TagHelpers.
+		/// </summary>
+		/// <param name="registrations"><see cref="ComponentRegistration"/> for more details</param>
+		/// <returns></returns>
+		/// <returns><see cref="WindsorRegistrationOptions"/> as a fluent interface</returns>
+		public WindsorRegistrationOptions RegisterTagHelpers(params IRegistration[] registrations)
+		{
+			TagHelperComponentRegistrations.AddRange(registrations);
 			return this;
 		}
 
@@ -93,7 +122,19 @@ namespace Castle.Facilities.AspNetCore
 		/// <returns><see cref="WindsorRegistrationOptions"/> as a fluent interface</returns>
 		public WindsorRegistrationOptions RegisterViewComponents(Assembly viewComponentsAssembly = null, LifestyleType lifestyleType = LifestyleType.Scoped)
 		{
-			ViewComponentRegistrations.Add((viewComponentsAssembly ?? EntryAssembly, lifestyleType));
+			ViewComponentAssemblyRegistrations.Add((viewComponentsAssembly ?? EntryAssembly, lifestyleType));
+			return this;
+		}
+
+		/// <summary>
+		/// Use this method for customising the registration of ViewComponents.
+		/// </summary>
+		/// <param name="registrations"><see cref="ComponentRegistration"/> for more details</param>
+		/// <returns></returns>
+		/// <returns><see cref="WindsorRegistrationOptions"/> as a fluent interface</returns>
+		public WindsorRegistrationOptions RegisterViewComponents(params IRegistration[] registrations)
+		{
+			ViewComponentComponentRegistrations.AddRange(registrations);
 			return this;
 		}
 	}


### PR DESCRIPTION
Expanded the registration options for ASP.NET Core facility to expose types like IRegistration. This would allow a Castle Windsor users to have more fine grained control over component registrations. 

An example would be:

```csharp
services.AddWindsor(container, opts =>
{
	opts.RegisterControllers(Component.For<HomeController>().LifestyleTransient());
	opts.RegisterTagHelpers(Component.For<EmailTagHelper>().LifestyleTransient());
	opts.RegisterViewComponents(Component.For<AddressComponent>().LifestyleTransient());
});
```

The defaults for registering Controllers, TagHelpers and ViewComponents have also been changed to use their least derived type(addressing issue #423). 

 - Controller becomes ControllerBase
 -  TagHelper becomes ITagHelper

This gives users maximum flexibility in the ASP.NET Core framework when it comes to implementing custom components that don't use ASP.NET Core's base behaviour.