### PR TITLE
Updating docs for CI/Preview builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ See the [releases](https://github.com/castleproject/Windsor/releases).
 
 Castle Windsor is &copy; 2004-2018 Castle Project. It is free software, and may be redistributed under the terms of the [Apache 2.0](http://opensource.org/licenses/Apache-2.0) license.
 
+## NuGet Preview Feed
+
+If you would like to use preview NuGet's from our CI builds on AppVeyor, you can add the following NuGet source to your project:
+
+```
+https://ci.appveyor.com/nuget/windsor-qkry8n2r6yak
+```
+
 ## Building
 
 ### Conditional Compilation Symbols


### PR DESCRIPTION
Just adding a link for folks that might want to pull down preview NuGets from AppVeyor. 

https://github.com/castleproject/Windsor/issues/395