### PR TITLE
Fix debug mode test failures

### DIFF
--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
@@ -24,6 +24,7 @@
 		<ProjectReference Include="..\Castle.Facilities.Logging\Castle.Facilities.Logging.csproj" />
 		<ProjectReference Include="..\Castle.Facilities.WcfIntegration.Demo\Castle.Facilities.WcfIntegration.Demo.csproj" />
 		<ProjectReference Include="..\Castle.Facilities.WcfIntegration\Castle.Facilities.WcfIntegration.csproj" />
+		<ProjectReference Include="..\Castle.Windsor.Tests\Castle.Windsor.Tests.csproj" />
 		<ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />
 	</ItemGroup>
 

--- a/src/Castle.Windsor.Tests/Lifecycle/DecomissioningResponsibilitiesTestCase.cs
+++ b/src/Castle.Windsor.Tests/Lifecycle/DecomissioningResponsibilitiesTestCase.cs
@@ -212,12 +212,10 @@ namespace CastleTests.Lifecycle
 		public void TransientReferencesAreNotHeldByContainer()
 		{
 			Kernel.Register(Component.For<EmptyClass>().LifeStyle.Transient);
-			var emptyClassWeakReference = new WeakReference(Kernel.Resolve<EmptyClass>());
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.IsFalse(emptyClassWeakReference.IsAlive);
+			ReferenceTracker
+				.Track(() => Kernel.Resolve<EmptyClass>())
+				.AssertNoLongerReferenced();
 		}
 
 		[Test]

--- a/src/Castle.Windsor.Tests/Lifecycle/DisposeTestCase.cs
+++ b/src/Castle.Windsor.Tests/Lifecycle/DisposeTestCase.cs
@@ -14,8 +14,6 @@
 
 namespace Castle.Windsor.Tests.Lifecycle
 {
-	using System;
-
 	using Castle.MicroKernel.Registration;
 	using Castle.Windsor.Tests.Facilities.TypedFactory.Components;
 
@@ -101,14 +99,17 @@ namespace Castle.Windsor.Tests.Lifecycle
 				Component.For<DisposableFoo>().LifeStyle.Singleton
 				);
 
-			var depender = Container.Resolve<GenericComponent<DisposableFoo>>();
-			var weak = new WeakReference(depender.Value);
-			depender = null;
+			var tracker = ReferenceTracker
+				.Track(() =>
+				{
+					var depender = Container.Resolve<GenericComponent<DisposableFoo>>();
+					return depender.Value;
+				});
+
 			Container.Dispose();
-			GC.Collect();
 
 			Assert.AreEqual(1, DisposableFoo.DisposedCount);
-			Assert.IsFalse(weak.IsAlive);
+			tracker.AssertNoLongerReferenced();
 		}
 
 		[Test]

--- a/src/Castle.Windsor.Tests/Lifecycle/InitializableTestCase.cs
+++ b/src/Castle.Windsor.Tests/Lifecycle/InitializableTestCase.cs
@@ -14,8 +14,6 @@
 
 namespace Castle.Windsor.Tests.Lifecycle
 {
-	using System;
-
 	using Castle.MicroKernel.Registration;
 
 	using CastleTests;
@@ -33,12 +31,9 @@ namespace Castle.Windsor.Tests.Lifecycle
 			                   	.ImplementedBy<SimpleServiceInitializable>()
 			                   	.LifeStyle.Transient);
 
-			var server = Container.Resolve<ISimpleService>();
-			var weak = new WeakReference(server);
-			server = null;
-			GC.Collect();
-
-			Assert.IsFalse(weak.IsAlive);
+			ReferenceTracker
+				.Track(() => Container.Resolve<ISimpleService>())
+				.AssertNoLongerReferenced();
 		}
 
 		[Test]

--- a/src/Castle.Windsor.Tests/Lifecycle/SupportsInitializeTestCase.cs
+++ b/src/Castle.Windsor.Tests/Lifecycle/SupportsInitializeTestCase.cs
@@ -15,8 +15,6 @@
 #if FEATURE_ISUPPORTINITIALIZE
 namespace Castle.Windsor.Tests.Lifecycle
 {
-	using System;
-
 	using Castle.MicroKernel.Registration;
 
 	using CastleTests;
@@ -34,12 +32,9 @@ namespace Castle.Windsor.Tests.Lifecycle
 			                   	.ImplementedBy<SimpleServiceSupportInitialize>()
 			                   	.LifeStyle.Transient);
 
-			var server = Container.Resolve<ISimpleService>();
-			var weak = new WeakReference(server);
-			server = null;
-			GC.Collect();
-
-			Assert.IsFalse(weak.IsAlive);
+			ReferenceTracker
+				.Track(() => Container.Resolve<ISimpleService>())
+				.AssertNoLongerReferenced();
 		}
 
 		[Test]

--- a/src/Castle.Windsor.Tests/Lifestyle/ScopedLifestyleTestCase.cs
+++ b/src/Castle.Windsor.Tests/Lifestyle/ScopedLifestyleTestCase.cs
@@ -184,20 +184,10 @@ namespace CastleTests.Lifestyle
 
 			using (Container.BeginScope())
 			{
-				var weakUdt = GetWeakReferenceToDisposableFoo();
-				GC.Collect();
-				Assert.IsFalse(weakUdt.IsAlive);
+				ReferenceTracker
+					.Track(() => Container.Resolve<UsesDisposableFoo>())
+					.AssertNoLongerReferenced();
 			}
-		}
-
-		// method is needed because since 4.6.x under debug configuration local variables are not
-		// considered for garbage collection; hence if method is inlined - test will fail
-		private WeakReference GetWeakReferenceToDisposableFoo()
-		{
-			var udf = Container.Resolve<UsesDisposableFoo>();
-			var weakUdt = new WeakReference(udf);
-			udf = null;
-			return weakUdt;
 		}
 
 		[Test]

--- a/src/Castle.Windsor.Tests/ReferenceTracker.cs
+++ b/src/Castle.Windsor.Tests/ReferenceTracker.cs
@@ -1,0 +1,137 @@
+﻿// Copyright 2018 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests
+{
+	using System;
+
+	using NUnit.Framework;
+
+	public static class ReferenceTracker
+	{
+		/// <summary>
+		/// <para>
+		/// Use a lambda method to evaluate an expression returning an object instance to track.
+		/// </para>
+		/// <para>
+		/// (If the expression is evaluated directly inside the test method, the runtime will keep it alive
+		/// until the test method returns if the runtime is in debug mode. ReSharper’s test runner runs in
+		/// debug mode when the active solution configuration is Debug.)
+		/// </para>
+		/// </summary>
+		public static ReferenceTracker<T> Track<T>(Func<T> getInstanceToTrack) where T : class
+		{
+			return ReferenceTracker<T>.Track(getInstanceToTrack);
+		}
+	}
+
+	/// <summary>
+	/// A test helper encapsulating correct reference tracking.
+	/// </summary>
+	public struct ReferenceTracker<T> where T : class
+	{
+		private readonly WeakReference weakReference;
+
+		private ReferenceTracker(WeakReference weakReference)
+		{
+			this.weakReference = weakReference;
+		}
+
+		/// <summary>
+		/// <para>
+		/// Use a lambda method to evaluate an expression returning an object instance to track.
+		/// </para>
+		/// <para>
+		/// (If the expression is evaluated directly inside the test method, the runtime will keep it alive
+		/// until the test method returns if the runtime is in debug mode. ReSharper’s test runner runs in
+		/// debug mode when the active solution configuration is Debug.)
+		/// </para>
+		/// </summary>
+		public static ReferenceTracker<T> Track(Func<T> getInstanceToTrack)
+		{
+			if (getInstanceToTrack == null)
+				throw new ArgumentNullException(nameof(getInstanceToTrack));
+
+			return new ReferenceTracker<T>(new WeakReference(getInstanceToTrack.Invoke()));
+		}
+
+		/// <summary>
+		/// Calls <see cref="GC.Collect()"/> and asserts that the tracked instance is still alive.
+		/// </summary>
+		public void AssertStillReferenced()
+		{
+			GC.Collect();
+			if (!weakReference.IsAlive)
+				Assert.Fail("The tracked instance is not longer referenced.");
+		}
+
+		/// <summary>
+		/// Calls <see cref="GC.Collect()"/> and asserts that the tracked instance is no longer alive.
+		/// </summary>
+		public void AssertNoLongerReferenced()
+		{
+			GC.Collect();
+			if (weakReference.IsAlive)
+				Assert.Fail("The tracked instance is still referenced.");
+		}
+
+		/// <summary>
+		/// <para>
+		/// Calls <see cref="GC.Collect()"/> and asserts that the tracked instance is still alive and
+		/// passes it to the specified action.
+		/// </para>
+		/// <para>
+		/// Be careful not to let the tracked instance become reachable via a local variable in the test method
+		/// or it will be kept alive until the end of the test method if the runtime is in debug mode.
+		/// (See <see cref="Track"/>.)
+		/// </para>
+		/// </summary>
+		public void AssertStillReferencedAndDo(Action<T> action)
+		{
+			if (action == null)
+				throw new ArgumentNullException(nameof(action));
+
+			GC.Collect();
+			var target = weakReference.Target;
+			if (target is null)
+				Assert.Fail("The tracked instance is not longer referenced.");
+
+			action.Invoke((T)target);
+		}
+
+		/// <summary>
+		/// <para>
+		/// Calls <see cref="GC.Collect()"/> and asserts that the tracked instance is still alive,
+		/// passes it to the specified function, and returns the value returned by the specified function.
+		/// </para>
+		/// <para>
+		/// Be careful not to let the tracked instance become reachable via a local variable in the test method
+		/// or it will be kept alive until the end of the test method if the runtime is in debug mode.
+		/// (See <see cref="Track"/>.)
+		/// </para>
+		/// </summary>
+		public TReturn AssertStillReferencedAndDo<TReturn>(Func<T, TReturn> func)
+		{
+			if (func == null)
+				throw new ArgumentNullException(nameof(func));
+
+			GC.Collect();
+			var target = weakReference.Target;
+			if (target is null)
+				Assert.Fail("The tracked instance is not longer referenced.");
+
+			return func.Invoke((T)target);
+		}
+	}
+}

--- a/src/Castle.Windsor.Tests/Registration/UsingFactoryMethodTestCase.cs
+++ b/src/Castle.Windsor.Tests/Registration/UsingFactoryMethodTestCase.cs
@@ -433,10 +433,9 @@ namespace CastleTests.Registration
 			                	.LifeStyle.Transient
 			                	.UsingFactoryMethod(() => new DisposableComponent(), managedExternally: true));
 
-			var weak = new WeakReference(Kernel.Resolve<DisposableComponent>());
-			GC.Collect();
-
-			Assert.IsFalse(weak.IsAlive);
+			ReferenceTracker
+				.Track(() => Kernel.Resolve<DisposableComponent>())
+				.AssertNoLongerReferenced();
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes #421. ~~The first commit isn't related (see commit message).~~ (now moved to #441)

There are now no occurrences of the text `GC.Collect` except in `ReferenceTracker.cs`, and no occurrences of the text `weak` (case insensitive) except in `ReferenceTracker.cs` and [`ModelFakes.cs`](https://github.com/castleproject/Windsor/blob/07e4b667c1826decdba1724642d6d68c2080c64e/src/Castle.Facilities.AspNetCore.Tests/Fakes/ModelFakes.cs#L38) (looks unrelated).

Hopefully the new test helper makes the tests easier to follow than they were before?