### PR TITLE
Update .gitignore so that NCrunch .user files are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,11 @@ AssemblyInfo.cs
 
 # Standard VS.NET and ReSharper Foo
 .vs/*
+*.user
 src/*/obj
 src/*/bin
 samples/*/obj
 samples/*/bin
-*.csproj.user
-*ReSharper.user
 _ReSharper*
 *.suo
 *.cache
@@ -18,8 +17,6 @@ _ReSharper*
 # Leftovers from merging
 *.orig
 *.bak
-*.sln.DotSettings.user
-*.DotSettings.user
 
 # Buildscripts artifacts
 buildscripts/**/obj/

--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,10 @@
 
 /build
-AssemblyInfo.cs
 
 # Standard VS.NET and ReSharper Foo
 .vs/*
 *.user
-src/*/obj
-src/*/bin
-samples/*/obj
-samples/*/bin
+bin/
+obj/
 _ReSharper*
 *.suo
-*.cache
-* Thumbs.db
-
-# Leftovers from merging
-*.orig
-*.bak
-
-# Buildscripts artifacts
-buildscripts/**/obj/
-buildscripts/**/bin/
-
-# Tools artifacts
-tools/**/obj/
-tools/**/build/
-
-# Docs artifacts
-docs/obj/
-docs/bin/


### PR DESCRIPTION
NCrunch kept adding a file tracked by git, so I added this standard list. Handling it this way makes for easy updates over time as VS and common tools change.

The virtue of cleaning up the manual section is that everything should just work and we can focus on what is unique to this project.

/cc @jonorossi, @stakx