### PR TITLE
Fixes of String.Format

### DIFF
--- a/src/Castle.Facilities.WcfIntegration/Client/WcfClientActivator.cs
+++ b/src/Castle.Facilities.WcfIntegration/Client/WcfClientActivator.cs
@@ -253,7 +253,7 @@ namespace Castle.Facilities.WcfIntegration
 			if (model.Services.Contains(contract) == false)
 			{
 				throw new FacilityException(string.Format(
-					"The service contract {0} is not supported by the component {0} or any of its services.",
+					"The service contract {0} is not supported by the component {1} or any of its services.",
 					clientModel.Contract.FullName, model.Implementation.FullName));
 			}
 		}

--- a/src/Castle.Windsor.Tests/LoggingFacility/ExtendedNLogFacilityTests.cs
+++ b/src/Castle.Windsor.Tests/LoggingFacility/ExtendedNLogFacilityTests.cs
@@ -63,7 +63,7 @@ namespace Castle.Facilities.Logging.Tests
 			smtpServer.InternalSend("rbellamy@pteradigm.com", "jobs@castlestronghold.com", "We're looking for a few good porgrammars.");
 			smtpServer.Stop();
 
-			expectedLogOutput = String.Format("|INFO|Castle.Facilities.Logging.Tests.Classes.SmtpServer|InternalSend rbellamy@pteradigm.com jobs@castlestronghold.com We're looking for a few good porgrammars.", typeof(SmtpServer).FullName);
+			expectedLogOutput = String.Format("|INFO|{0}|InternalSend rbellamy@pteradigm.com jobs@castlestronghold.com We're looking for a few good porgrammars.", typeof(SmtpServer).FullName);
 			actualLogOutput = (NLog.LogManager.Configuration.FindTargetByName("memory") as MemoryTarget).Logs[1].ToString();
 			actualLogOutput = actualLogOutput.Substring(actualLogOutput.IndexOf('|'));
 			
@@ -79,7 +79,7 @@ namespace Castle.Facilities.Logging.Tests
 
 			complexLoggingComponent.DoSomeContextual();
 
-			String expectedLogOutput = String.Format("|DEBUG|Castle.Facilities.Logging.Tests.Classes.ComplexLoggingComponent|flam|bar|Outside Inside0|Bim, bam boom.", typeof(ComplexLoggingComponent).FullName);
+			String expectedLogOutput = String.Format("|DEBUG|{0}|flam|bar|Outside Inside0|Bim, bam boom.", typeof(ComplexLoggingComponent).FullName);
 			String actualLogOutput = (NLog.LogManager.Configuration.FindTargetByName("memory1") as MemoryTarget).Logs[0].ToString();
 			actualLogOutput = actualLogOutput.Substring(actualLogOutput.IndexOf('|'));
 


### PR DESCRIPTION
Put arguments in appropriate places in String.Format method.