### PR TITLE
Finding the controller should be made in a case insensitive way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Windsor Changelog
 
+## Unreleased
+
+Bugfixes:
+- Finding the controller should be made in a case insensitive way for Castle.Facilities.AspNet.Mvc facility (@yitzchok, #480)
+
 ## 5.0.0 (2019-02-12)
 
 Bugfixes:

--- a/src/Castle.Facilities.AspNet.Mvc.Tests/ControllerFinderTestCase.cs
+++ b/src/Castle.Facilities.AspNet.Mvc.Tests/ControllerFinderTestCase.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Facilities.AspNet.Mvc.Tests
+{
+	using System.Web.Mvc;
+	using System.Web.Routing;
+
+	using Castle.Facilities.AspNet.Mvc;
+	using Castle.MicroKernel.Lifestyle;
+	using Castle.MicroKernel.Registration;
+	using Castle.Windsor;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class ControllerFinderTestCase
+	{
+		private AspNetMvcFacility facility = null;
+		private WindsorContainer container;
+
+		[SetUp]
+		public void SetUp()
+		{
+			container = new WindsorContainer();
+
+			container.AddFacility<AspNetMvcFacility>(x =>
+			{
+				facility = x;
+				x.AddControllerAssembly<MvcTestController>();
+			});
+		}
+
+		[TestCase("MvcTest")]
+		[TestCase("mvctest")]
+		[TestCase("Mvctest")]
+		[TestCase("MVCtest")]
+		public void Should_find_controller_by_name_ignoring_case(string controllerName)
+		{
+			container.Register(Component.For<MvcTestController>().LifestyleScoped());
+
+			var result = ResolveController(controllerName);
+
+			Assert.That(typeof(MvcTestController), Is.EqualTo(result.GetType()));
+		}
+
+		private IController ResolveController(string controllerName)
+		{
+			using (container.BeginScope())
+				return facility.ControllerFactory.CreateController(new RequestContext(), controllerName);
+		}
+
+		public class MvcTestController : Controller
+		{
+		}
+	}
+}

--- a/src/Castle.Facilities.AspNet.Mvc/AspNetMvcControllerFactory.cs
+++ b/src/Castle.Facilities.AspNet.Mvc/AspNetMvcControllerFactory.cs
@@ -24,7 +24,6 @@ namespace Castle.Facilities.AspNet.Mvc
 	using System.Web.Routing;
 	using System.Web.SessionState;
 
-	using Castle.Core.Internal;
 	using Castle.Facilities.AspNet.Mvc.Exceptions;
 	using Castle.MicroKernel;
 	using Castle.MicroKernel.Lifestyle;
@@ -101,7 +100,7 @@ namespace Castle.Facilities.AspNet.Mvc
 		{
 			foreach (var type in this.controllerCandidateTypes)
 			{
-				if (type.Name.EqualsText(controllerName))
+				if (type.Name.Equals(controllerName, StringComparison.OrdinalIgnoreCase))
 				{
 					return type;
 				}

--- a/src/Castle.Facilities.AspNet.Mvc/AspNetMvcControllerFactory.cs
+++ b/src/Castle.Facilities.AspNet.Mvc/AspNetMvcControllerFactory.cs
@@ -24,6 +24,7 @@ namespace Castle.Facilities.AspNet.Mvc
 	using System.Web.Routing;
 	using System.Web.SessionState;
 
+	using Castle.Core.Internal;
 	using Castle.Facilities.AspNet.Mvc.Exceptions;
 	using Castle.MicroKernel;
 	using Castle.MicroKernel.Lifestyle;
@@ -35,9 +36,9 @@ namespace Castle.Facilities.AspNet.Mvc
 		private readonly IKernel kernel;
 		private bool autoCreateLifestyleScopes;
 		private SessionStateBehavior sessionStateBehaviour;
-        private IEnumerable<Type> controllerCandidateTypes;
+		private IEnumerable<Type> controllerCandidateTypes;
 
-        public event Action<IKernel, Type> BeforeControllerResolved;
+		public event Action<IKernel, Type> BeforeControllerResolved;
 		public event Action<IKernel, object> AfterControllerReleased;
 
 		public AspNetMvcControllerFactory(IKernel kernel, bool autoCreateLifestyleScopes, SessionStateBehavior sessionStateBehaviour, List<Assembly> controllerAssemblies)
@@ -100,7 +101,7 @@ namespace Castle.Facilities.AspNet.Mvc
 		{
 			foreach (var type in this.controllerCandidateTypes)
 			{
-				if (type.Name == controllerName)
+				if (type.Name.EqualsText(controllerName))
 				{
 					return type;
 				}
@@ -125,7 +126,5 @@ namespace Castle.Facilities.AspNet.Mvc
 				HttpContext.Current.Items.Remove(ContextScopeKey);
 			}
 		}
-
-		
 	}
 }


### PR DESCRIPTION
This is for AspNetMvcFacility.
When searching for a controller matching the url from the web request we shouldn't care about the case.