### PR TITLE
Suppress NuGet `licenseUrl` deprecation warning

### DIFF
--- a/src/Castle.Facilities.AspNet.Mvc/Castle.Facilities.AspNet.Mvc.csproj
+++ b/src/Castle.Facilities.AspNet.Mvc/Castle.Facilities.AspNet.Mvc.csproj
@@ -13,6 +13,7 @@
 		<Description>Castle Windsor Mvc facility lets you easily add windsor to aspnet mvc web apps.</Description>
 		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection, aspnet, mvc</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Facilities.AspNet.Mvc</AssemblyName>
 		<RootNamespace>Castle.Facilities.AspNet.Mvc</RootNamespace>
 	</PropertyGroup>

--- a/src/Castle.Facilities.AspNet.SystemWeb/Castle.Facilities.AspNet.SystemWeb.csproj
+++ b/src/Castle.Facilities.AspNet.SystemWeb/Castle.Facilities.AspNet.SystemWeb.csproj
@@ -13,6 +13,7 @@
 		<Description>Castle Windsor system web facility lets you easily add windsor to legacy aspnet web apps.</Description>
 		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection, system, web, aspnet</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Facilities.AspNet.SystemWeb</AssemblyName>
 		<RootNamespace>Castle.Facilities.AspNet.SystemWeb</RootNamespace>
 	</PropertyGroup>

--- a/src/Castle.Facilities.AspNet.WebApi/Castle.Facilities.AspNet.WebApi.csproj
+++ b/src/Castle.Facilities.AspNet.WebApi/Castle.Facilities.AspNet.WebApi.csproj
@@ -13,6 +13,7 @@
 		<Description>Castle Windsor WebApi facility lets you easily add windsor to aspnet webapi apps.</Description>
 		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection, aspnet, webapi</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Facilities.AspNet.WebApi</AssemblyName>
 		<RootNamespace>Castle.Facilities.AspNet.WebApi</RootNamespace>
 	</PropertyGroup>

--- a/src/Castle.Facilities.AspNetCore/Castle.Facilities.AspNetCore.csproj
+++ b/src/Castle.Facilities.AspNetCore/Castle.Facilities.AspNetCore.csproj
@@ -13,6 +13,7 @@
 		<Description>Castle Windsor ASP.NET Core facility lets you easily add windsor to aspnet core apps.</Description>
 		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection, aspnet, core</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Facilities.AspNetCore</AssemblyName>
 		<RootNamespace>Castle.Facilities.AspNetCore</RootNamespace>
 	</PropertyGroup>

--- a/src/Castle.Facilities.Logging/Castle.Facilities.Logging.csproj
+++ b/src/Castle.Facilities.Logging/Castle.Facilities.Logging.csproj
@@ -13,6 +13,7 @@
 		<Description>Castle Windsor logging facility lets you easily inject loggers into your components. It offers integration with most popular 3rd party logging frameworks like log4net, NLog and Serilog (see Castle Core docs).</Description>
 		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection, logging, log4net, nlog</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Facilities.Logging</AssemblyName>
 		<RootNamespace>Castle.Facilities.Logging</RootNamespace>
 	</PropertyGroup>

--- a/src/Castle.Facilities.WcfIntegration/Castle.Facilities.WcfIntegration.csproj
+++ b/src/Castle.Facilities.WcfIntegration/Castle.Facilities.WcfIntegration.csproj
@@ -10,6 +10,7 @@
 		<Description>Castle Windsor WCF Integration facility enables integration with Windows Communication Foundation. It makes services and WCF proxies available as services in your application, lets you use non-default constructor and inject dependencies into your services, adds ability to easily set up your services with extensions, call services asynchronously without needing to use code generation and much more.</Description>
 		<PackageTags>castle windsor, inversionOfControl, DependencyInjection</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Facilities.WcfIntegration</AssemblyName>
 		<RootNamespace>Castle.Facilities.WcfIntegration</RootNamespace>
 	</PropertyGroup>

--- a/src/Castle.Windsor/Castle.Windsor.csproj
+++ b/src/Castle.Windsor/Castle.Windsor.csproj
@@ -13,6 +13,7 @@
 		<Description>Castle Windsor is best of breed, mature Inversion of Control container available for .NET.</Description>
 		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection</PackageTags>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
 		<AssemblyName>Castle.Windsor</AssemblyName>
 		<RootNamespace>Castle</RootNamespace>
 		<Title>Castle Windsor</Title>


### PR DESCRIPTION
I can no longer get Windsor to build due to that pesky NuGet _"The `licenseUrl` element will be deprecated"_ warning combined with Windsor's use of `<TreatWarningsAsErrors>`.

This adds a suppression for that warning as per https://github.com/castleproject/NVelocity/issues/14#issuecomment-476650487.

(Regarding the duplication in this PR, I refrained from putting the suppression in a [`common.props` like Core has got](https://github.com/castleproject/Core/blob/0f5bdb7c20d1d65aab60ddbf9fe8a92b56307b4b/buildscripts/common.props), or even in a default [MSBuild `Directory.Build.props`](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2017#directorybuildprops-and-directorybuildtargets). Reorganizing the build is probably best left to another dedicated PR.)