### PR TITLE
Separated the .NET Core handling from the specific ASP.NET additional…

### DIFF
--- a/Castle.Windsor.sln
+++ b/Castle.Windsor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.452
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Windsor", "src\Castle.Windsor\Castle.Windsor.csproj", "{5F6A631E-8EB1-4BC1-826D-86D3059945B8}"
 EndProject
@@ -50,6 +50,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Facilities.AspNet.WebApi", "src\Castle.Facilities.AspNet.WebApi\Castle.Facilities.AspNet.WebApi.csproj", "{501276B2-166F-40CA-AFF0-2F2D70BF4E4F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Facilities.AspNet.WebApi.Tests", "src\Castle.Facilities.AspNet.WebApi.Tests\Castle.Facilities.AspNet.WebApi.Tests.csproj", "{5CD7AE3F-105F-4C7A-940D-B7D130940E66}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Facilities.NetCore", "src\Castle.Facilities.NetCore\Castle.Facilities.NetCore.csproj", "{0FDC021C-BD89-4841-BCCF-0CDAF39FE72A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -121,6 +123,10 @@ Global
 		{5CD7AE3F-105F-4C7A-940D-B7D130940E66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CD7AE3F-105F-4C7A-940D-B7D130940E66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CD7AE3F-105F-4C7A-940D-B7D130940E66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FDC021C-BD89-4841-BCCF-0CDAF39FE72A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FDC021C-BD89-4841-BCCF-0CDAF39FE72A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FDC021C-BD89-4841-BCCF-0CDAF39FE72A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FDC021C-BD89-4841-BCCF-0CDAF39FE72A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -140,6 +146,7 @@ Global
 		{175EF5FC-C3A5-4EE4-BFE6-77F0A53CBA3B} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
 		{501276B2-166F-40CA-AFF0-2F2D70BF4E4F} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
 		{5CD7AE3F-105F-4C7A-940D-B7D130940E66} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
+		{0FDC021C-BD89-4841-BCCF-0CDAF39FE72A} = {7935AFF5-BF6D-4D59-8D66-058B6557F70F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CC2A1EB6-49EC-4064-AD8B-29439E8A45E4}

--- a/Castle.Windsor.sln
+++ b/Castle.Windsor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.452
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.Windsor", "src\Castle.Windsor\Castle.Windsor.csproj", "{5F6A631E-8EB1-4BC1-826D-86D3059945B8}"
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ on_success:
         nuget push ".\build\Castle.Facilities.AspNet.SystemWeb.${env:APPVEYOR_BUILD_VERSION}.nupkg" -ApiKey $env:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
         nuget push ".\build\Castle.Facilities.AspNet.Mvc.${env:APPVEYOR_BUILD_VERSION}.nupkg" -ApiKey $env:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
         nuget push ".\build\Castle.Facilities.AspNet.WebApi.${env:APPVEYOR_BUILD_VERSION}.nupkg" -ApiKey $env:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
+        nuget push ".\build\Castle.Facilities.NetCore.${env:APPVEYOR_BUILD_VERSION}.nupkg" -ApiKey $env:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
         nuget push ".\build\Castle.Facilities.AspNetCore.${env:APPVEYOR_BUILD_VERSION}.nupkg" -ApiKey $env:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
         nuget push ".\build\Castle.WcfIntegrationFacility.${env:APPVEYOR_BUILD_VERSION}.nupkg" -ApiKey $env:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
     }

--- a/buildscripts/build.cmd
+++ b/buildscripts/build.cmd
@@ -69,6 +69,7 @@ GOTO nuget_explicit_versions
 
 .\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.windsor"
 .\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.loggingfacility"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.netcore"
 .\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnetcore"
 .\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnet.mvc"
 .\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnet.webapi"

--- a/docs/aspnetcore-facility.md
+++ b/docs/aspnetcore-facility.md
@@ -3,6 +3,8 @@
 :warning: **Unreleased:** This page describes a feature that is not yet released, check the issue tracker for details.
 
 The ASP.NET Core facility provides Castle Windsor integration using a custom activators for .NET Core web based projects.
+If you are not working in a ASP.Net.Core web project, you can use the [.NET Core Facility](netcore-facility.md) instead.
+It doesn't try to register all controller,taghelpes and viewcomponents.
 
  - [IControllerActivator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllers.icontrolleractivator?view=aspnetcore-2.0) 
  - [ITagHelperActivator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.razor.itaghelperactivator?view=aspnetcore-2.0) 

--- a/docs/facilities.md
+++ b/docs/facilities.md
@@ -43,6 +43,7 @@ In addition to the above, as part of Castle Project, some other facilities are p
 * [System Web Facility](systemweb-facility.md) - Provides System.Web integration for web projects using `PerWebRequest` lifestyles.
 * [ASP.NET MVC Facility](aspnetmvc-facility.md) - Provides ASP.NET MVC integration for web projects using Windsor.
 * [ASP.NET WebApi Facility](aspnetwebapi-facility.md) - Provides ASP.NET Web API integration for web projects using Windsor.
+* [.NET Core Facility](netcore-facility.md) - Provides .NET Core integration for .NET Core projects using Windsor.
 * [ASP.NET Core Facility](aspnetcore-facility.md) - Provides ASP.NET Core integration for web projects using Windsor.
 
 ## Third Party Facilities

--- a/docs/netcore-facility.md
+++ b/docs/netcore-facility.md
@@ -1,0 +1,145 @@
+﻿# ASP.NET Core Facility
+
+:warning: **Unreleased:** This page describes a feature that is not yet released, check the issue tracker for details.
+
+The .NET Core facility provides Castle Windsor integration using a custom activators for .NET Core projects.
+
+
+## How does it work?
+
+
+This method  adds a sub resolver for dealing with the resolution of .NET Core framework types. An example might be something like an 
+[ILoggerFactory](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.iloggerfactory?view=aspnetcore-2.0). 
+You can also register your components with a finer grain of control by using the IRegistration[] overloads. Example below:
+
+```csharp
+services.AddWindsor(container, opts =>
+{
+	opts.RegisterControllers(Component.For<HomeController>().LifestyleTransient());
+	opts.RegisterTagHelpers(Component.For<EmailTagHelper>().LifestyleTransient());
+	opts.RegisterViewComponents(Component.For<AddressComponent>().LifestyleTransient());
+});
+```
+
+Alternatively if your framework components all live in one assembly and you dont need to change lifestyles then you can simply use the following:
+
+```csharp
+services.AddWindsor(container, opts =>
+{
+	opts.UseEntryAssembly(typeof(HomeController).Assembly);
+});
+```
+This is good for trouble shooting situations where nothing get's registered because of problems in the hosting environment where 
+GetEntryAssembly/GetCallingAssembly does not work as expected. 
+
+### Cross Wiring into the IServiceCollection
+
+There is an additional feature you can use to `Cross Wire` components into the IServiceCollection. This is useful 
+for cases where the framework needs to know how to resolve a component from Windsor. An example would be components 
+consumed with the Razor @Inject directive in MVC projects. 
+
+```csharp
+container.Register(Component.For<IUserService>().ImplementedBy<AspNetUserService>().LifestyleScoped().CrossWired());
+```
+
+This would then allow you to consume the IUserService component in your Razor view like so:
+
+```html
+@inject WebApp.IUserService user
+
+@foreach (var user in user.GetAll())
+{
+	<div>
+		<h1>@user</h1>
+	</div>
+}
+```
+
+For this to work you have add the facility in the configure services method before you register anything. A helpful exception
+will be thrown in case you forget.
+
+```csharp
+public IServiceProvider ConfigureServices(IServiceCollection services)
+{
+	// Setup component model contributors for making windsor services available to IServiceProvider
+	Container.AddFacility<NetCoreFacility>(f => f.CrossWiresInto(services));
+	
+	//...
+}
+```
+:warning: **Nesting CrossWired Dependencies** The ServiceProvider is quite greedy in the way that it manages disposables, if both Windsor and the ServiceProvider try track them together things end up getting disposed more than once. So to make this work Windsor has to relinquish disposable concerns to the ServiceProvider for `Cross Wired` components. If `Cross Wired` components depend to on each other, you might end up introducing a memory leak into your application(except for singletons) especially if they did not get disposed/released properly. Please use `Cross Wired` components sparingly.
+
+
+## What do I need to set it up?
+
+You will need to install the Castle.Facilities.NetCore nuget, after which you can add the missing code to your Startup.cs. 
+Here is a complete example:
+
+```csharp
+public class Startup
+{
+	private static readonly WindsorContainer Container = new WindsorContainer();
+
+	public Startup(IHostingEnvironment env)
+	{
+		var builder = new ConfigurationBuilder()
+			.SetBasePath(env.ContentRootPath)
+			.AddJsonFile("appsettings.json", true, true)
+			.AddJsonFile($"appsettings.{env.EnvironmentName}.json", true)
+			.AddEnvironmentVariables();
+
+		Configuration = builder.Build();
+	}
+
+	public IConfigurationRoot Configuration { get; }
+
+	// This method gets called by the runtime. Use this method to add application services to the application.
+	public IServiceProvider ConfigureServices(IServiceCollection services)
+	{
+		// Setup component model contributors for making windsor services available to IServiceProvider
+		Container.AddFacility<NetCoreFacility>(f => f.CrossWiresInto(services));
+
+		// Add framework services.
+		services.AddMvc();
+		services.AddLogging((lb) => lb.AddConsole().AddDebug());
+		services.AddSingleton<FrameworkMiddleware>(); // Do this if you don't care about using Windsor to inject dependencies
+
+		// Custom application component registrations, ordering is important here
+		RegisterApplicationComponents(services);
+
+		// Castle Windsor integration, controllers, tag helpers and view components, this should always come after RegisterApplicationComponents
+		return services.AddWindsor(Container, 
+			opts => opts.UseEntryAssembly(typeof(HomeController).Assembly), // <- Recommended
+			() => services.BuildServiceProvider(validateScopes:false)); // <- Optional
+	}
+
+}
+
+
+
+### Torn lifestyles
+
+If you register an application component such as a singleton in Windsor and ASP.NET Core framework two instances might appear. 
+This is known as a `torn lifestyle`. We hope to have avoided this in this facility's design but it is useful to know what 
+symptoms to look for if this does happen.
+
+Please report any evidence of this on our issue tracker.
+
+References:
+ - https://simpleinjector.readthedocs.io/en/latest/tornlifestyle.html
+
+### Captive Dependencies
+
+This is when Windsor services with `long lived`(ie. Singleton) lifestyles, consume components that were registered with 
+`short lived`(ie. Transient, Scoped) lifestyles. The service dependency is effectively held captive by it's consumer 
+lifestyle. Symptoms here could include dispose method's not firing for transients and scopes that are consumed by singletons. 
+
+References:
+ - http://blog.ploeh.dk/2014/06/02/captive-dependency/
+
+### Special credit:
+
+ - [@dotnetjunkie](https://github.com/dotnetjunkie) for pioneering the discussions with the ASP.NET team for non-conforming containers and providing valuable input on issue: https://github.com/castleproject/Windsor/issues/120 
+ - [@ploeh](https://github.com/ploeh) for defining `Captive Dependencies`: http://blog.ploeh.dk/2014/06/02/captive-dependency/
+ - [@hikalkan](https://github.com/hikalkan) for implementing https://github.com/volosoft/castle-windsor-ms-adapter. 
+ - [@generik0](https://github.com/generik0) for providing invaluable feedback into the public API's and test driving this in a real world application.

--- a/docs/netcore-facility.md
+++ b/docs/netcore-facility.md
@@ -1,8 +1,10 @@
-﻿# ASP.NET Core Facility
+﻿# .NET Core Facility
 
 :warning: **Unreleased:** This page describes a feature that is not yet released, check the issue tracker for details.
 
 The .NET Core facility provides Castle Windsor integration using a custom activators for .NET Core projects.
+
+If working in a ASP.Net.Core web project, you should use the [ASP.NET Core Facility](aspnetcore-facility.md)
 
 
 ## How does it work?

--- a/src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
+++ b/src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
@@ -16,6 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\Castle.Facilities.NetCore\Castle.Facilities.NetCore.csproj" />
 	  <ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />
 	  <ProjectReference Include="..\Castle.Facilities.AspNetCore\Castle.Facilities.AspNetCore.csproj" />
 	</ItemGroup>

--- a/src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
+++ b/src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
@@ -8,7 +8,7 @@
 		<!-- This is an intentional upgrade to NUnit. This is the solution for https://github.com/castleproject/Windsor/issues/243 once we upgrade NUnit and make dotnet test a first class citizen-->
 		<PackageReference Include="NUnit" Version="3.8.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
 		<PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.0.2" />

--- a/src/Castle.Facilities.AspNetCore.Tests/Fakes/ModelFakes.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Fakes/ModelFakes.cs
@@ -26,6 +26,8 @@ namespace Castle.Facilities.AspNetCore.Tests.Fakes
 	using Microsoft.AspNetCore.Razor.TagHelpers;
 	using Microsoft.Extensions.DependencyInjection;
 
+	using Castle.Facilities.NetCore;
+
 	public partial class OpenOptions {}
 	public partial class ClosedOptions {}
 

--- a/src/Castle.Facilities.AspNetCore.Tests/Framework/Builders/WindsorContainerBuilder.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Framework/Builders/WindsorContainerBuilder.cs
@@ -17,6 +17,7 @@ namespace Castle.Facilities.AspNetCore.Tests.Framework.Builders
 	using System;
 
 	using Castle.Facilities.AspNetCore.Tests.Fakes;
+	using Castle.Facilities.NetCore;
 	using Castle.Windsor;
 
 	using Microsoft.AspNetCore.Builder;

--- a/src/Castle.Facilities.AspNetCore.Tests/Framework/Builders/WindsorContainerBuilder.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Framework/Builders/WindsorContainerBuilder.cs
@@ -17,6 +17,7 @@ namespace Castle.Facilities.AspNetCore.Tests.Framework.Builders
 	using System;
 
 	using Castle.Facilities.AspNetCore.Tests.Fakes;
+	using Castle.Facilities.AspNetCore;
 	using Castle.Facilities.NetCore;
 	using Castle.Windsor;
 
@@ -36,7 +37,7 @@ namespace Castle.Facilities.AspNetCore.Tests.Framework.Builders
 
 			RegisterApplicationComponents(container, services);
 
-			services.AddWindsor(container, configure, serviceProviderFactory);
+			services.AddWindsorForAspNet(container, configure, serviceProviderFactory);
 
 			return container;
 		}

--- a/src/Castle.Facilities.AspNetCore.Tests/Framework/TestContextFactory.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Framework/TestContextFactory.cs
@@ -18,6 +18,7 @@ namespace Castle.Facilities.AspNetCore.Tests.Framework
 
 	using Castle.MicroKernel.Lifestyle;
 	using Castle.Facilities.AspNetCore.Tests.Framework.Builders;
+	using Castle.Facilities.NetCore;
 
 	public class TestContextFactory
 	{

--- a/src/Castle.Facilities.AspNetCore.Tests/Resolvers/FrameworkDependencyResolverTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Resolvers/FrameworkDependencyResolverTestCase.cs
@@ -17,7 +17,7 @@ namespace Castle.Facilities.AspNetCore.Tests.Resolvers
 	using System;
 
 	using Castle.Facilities.AspNetCore.Tests.Fakes;
-	using Castle.Facilities.AspNetCore.Resolvers;
+	using Castle.Facilities.NetCore.Resolvers;
 	using Castle.Facilities.AspNetCore.Tests.Framework;
 
 	using Microsoft.Extensions.DependencyInjection;

--- a/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationExtensionsTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationExtensionsTestCase.cs
@@ -17,6 +17,7 @@ namespace Castle.Facilities.AspNetCore.Tests
 	using System;
 
 	using Castle.Core;
+	using Castle.Facilities.NetCore;
 	using Castle.Facilities.AspNetCore.Tests.Fakes;
 	using Castle.Facilities.AspNetCore.Tests.Framework;
 	using Castle.MicroKernel.Registration;

--- a/src/Castle.Facilities.AspNetCore/AspNetCoreFacility.cs
+++ b/src/Castle.Facilities.AspNetCore/AspNetCoreFacility.cs
@@ -17,6 +17,7 @@ namespace Castle.Facilities.AspNetCore
 	using System;
 
 	using Castle.Facilities.AspNetCore.Contributors;
+	using Castle.Facilities.NetCore;
 	using Castle.MicroKernel.Facilities;
 	using Castle.Windsor;
 
@@ -24,27 +25,18 @@ namespace Castle.Facilities.AspNetCore
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.Extensions.DependencyInjection;
 
-	public class AspNetCoreFacility : AbstractFacility
+	public class AspNetCoreFacility : NetCoreFacility
 	{
-		internal const string IsCrossWiredIntoServiceCollectionKey = "windsor-registration-is-also-registered-in-service-collection";
 		internal const string IsRegisteredAsMiddlewareIntoApplicationBuilderKey = "windsor-registration-is-also-registered-as-middleware";
 
-		private CrossWiringComponentModelContributor crossWiringComponentModelContributor;
 		private MiddlewareComponentModelContributor middlewareComponentModelContributor;
 
 		protected override void Init()
 		{
-			Kernel.ComponentModelBuilder.AddContributor(crossWiringComponentModelContributor ?? throw new InvalidOperationException("Please call `Container.AddFacility<AspNetCoreFacility>(f => f.CrossWiresInto(services));` first. This should happen before any cross wiring registration. Please see https://github.com/castleproject/Windsor/blob/master/docs/aspnetcore-facility.md"));
+			base.Init();
 		}
 
-		/// <summary>
-		/// Installation of the <see cref="CrossWiringComponentModelContributor"/> for registering components in both the <see cref="IWindsorContainer"/> and the <see cref="IServiceCollection"/> via the <see cref="WindsorRegistrationExtensions.CrossWired"/> component registration extension
-		/// </summary>
-		/// <param name="services"><see cref="IServiceCollection"/></param>
-		public void CrossWiresInto(IServiceCollection services)
-		{
-			crossWiringComponentModelContributor = new CrossWiringComponentModelContributor(services);
-		}
+
 
 		/// <summary>
 		/// Registers Windsor `aware` <see cref="IMiddleware"/> into the <see cref="IApplicationBuilder"/> via the <see cref="WindsorRegistrationExtensions.AsMiddleware"/> component registration extension

--- a/src/Castle.Facilities.AspNetCore/Castle.Facilities.AspNetCore.csproj
+++ b/src/Castle.Facilities.AspNetCore/Castle.Facilities.AspNetCore.csproj
@@ -26,6 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\Castle.Facilities.NetCore\Castle.Facilities.NetCore.csproj" />
 	  <ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />
 	</ItemGroup>
 

--- a/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
@@ -16,12 +16,13 @@ namespace Castle.Facilities.AspNetCore
 {
 	using System;
 	using System.Linq;
-
-	using Castle.Facilities.AspNetCore.Resolvers;
+	using Castle.Facilities.NetCore;
+	using Castle.Facilities.NetCore.Resolvers;
 	using Castle.MicroKernel.Lifestyle;
 	using Castle.MicroKernel.Registration;
 	using Castle.MicroKernel.Resolvers.SpecializedResolvers;
 	using Castle.Windsor;
+
 
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc;
@@ -48,25 +49,6 @@ namespace Castle.Facilities.AspNetCore
 			return InitialiseFrameworkServiceProvider(services, serviceProviderFactory, container);
 		}
 
-		/// <summary>
-		/// For making types available to the <see cref="IServiceCollection"/> using 'late bound' factories which resolve from Windsor. This makes things like the @Inject directive in Razor work.
-		/// </summary>
-		/// <param name="registration">The component registration that gets copied across to the <see cref="IServiceCollection"/></param>
-		public static ComponentRegistration CrossWired(this ComponentRegistration registration)
-		{
-			registration.Attribute(AspNetCoreFacility.IsCrossWiredIntoServiceCollectionKey).Eq(Boolean.TrueString);
-			return registration;
-		}
-
-		/// <summary>
-		/// For making types available to the <see cref="IServiceCollection"/> using 'late bound' factories which resolve from Windsor. This makes things like the @Inject directive in Razor work.
-		/// </summary>
-		/// <param name="registration">The component registration that gets copied across to the IServiceCollection</param>
-		public static ComponentRegistration<T> CrossWired<T>(this ComponentRegistration<T> registration) where T : class
-		{
-			registration.Attribute(AspNetCoreFacility.IsCrossWiredIntoServiceCollectionKey).Eq(Boolean.TrueString);
-			return registration;
-		}
 
 		/// <summary>
 		/// For registering middleware that is resolved from Windsor

--- a/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
@@ -38,7 +38,7 @@ namespace Castle.Facilities.AspNetCore
 		/// <param name="container"><see cref="IWindsorContainer"/></param>
 		/// <param name="configure">Configuration options for controlling registration and lifestyles of controllers, tagHelpers and viewComponents</param>
 		/// <param name="serviceProviderFactory">Optional factory for creating a custom <see cref="IServiceProvider"/></param>
-		public static IServiceProvider AddWindsor(this IServiceCollection services, IWindsorContainer container, Action<WindsorRegistrationOptions> configure = null, Func<IServiceProvider> serviceProviderFactory = null)
+		public static IServiceProvider AddWindsorForAspNet(this IServiceCollection services, IWindsorContainer container, Action<WindsorRegistrationOptions> configure = null, Func<IServiceProvider> serviceProviderFactory = null)
 		{
 			var options = new WindsorRegistrationOptions();
 			configure?.Invoke(options);

--- a/src/Castle.Facilities.NetCore/Castle.Facilities.NetCore.csproj
+++ b/src/Castle.Facilities.NetCore/Castle.Facilities.NetCore.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+
+	<Import Project="..\..\buildscripts\common.props"></Import>
+
+	<PropertyGroup>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageId>Castle.Facilities.NetCore</PackageId>
+		<Title>Castle Windsor .NET Core facility</Title>
+		<Description>Castle Windsor .NET Core facility lets you easily add windsor to .net core apps.</Description>
+		<PackageTags>castle, windsor, inversionOfControl, DependencyInjection, core</PackageTags>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>$(NoWarn);NU5125</NoWarn> <!-- remove once tools are truly ready for NuGet's new 'license' element -->
+		<AssemblyName>Castle.Facilities.NetCore</AssemblyName>
+		<RootNamespace>Castle.Facilities.NetCore</RootNamespace>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Castle.Facilities.NetCore/Contributors/CrossWiringComponentModelContributor.cs
+++ b/src/Castle.Facilities.NetCore/Contributors/CrossWiringComponentModelContributor.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Facilities.AspNetCore.Contributors
+namespace Castle.Facilities.NetCore.Contributors
 {
 	using System;
 	using System.Linq;
@@ -33,12 +33,12 @@ namespace Castle.Facilities.AspNetCore.Contributors
 
 		public CrossWiringComponentModelContributor(IServiceCollection services)
 		{
-			this.services = services ?? throw new InvalidOperationException("Please call `Container.AddFacility<AspNetCoreFacility>(f => f.CrossWiresInto(services));` first. This should happen before any cross wiring registration. Please see https://github.com/castleproject/Windsor/blob/master/docs/aspnetcore-facility.md");
+			this.services = services ?? throw new InvalidOperationException("Please call `Container.AddFacility<NetCoreFacility>(f => f.CrossWiresInto(services));` first. This should happen before any cross wiring registration. Please see https://github.com/castleproject/Windsor/blob/master/docs/aspnetcore-facility.md");
 		}
 
 		public void ProcessModel(IKernel kernel, ComponentModel model)
 		{
-			if (model.Configuration.Attributes.Get(AspNetCoreFacility.IsCrossWiredIntoServiceCollectionKey) == Boolean.TrueString)
+			if (model.Configuration.Attributes.Get(NetCoreFacility.IsCrossWiredIntoServiceCollectionKey) == Boolean.TrueString)
 			{
 				if (model.Lifecycle.HasDecommissionConcerns)
 				{

--- a/src/Castle.Facilities.NetCore/NetCoreFacility.cs
+++ b/src/Castle.Facilities.NetCore/NetCoreFacility.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Facilities.NetCore
+{
+	using System;
+
+	using Castle.Facilities.NetCore.Contributors;
+	using Castle.MicroKernel.Facilities;
+	using Castle.Windsor;
+
+
+	using Microsoft.Extensions.DependencyInjection;
+
+	public class NetCoreFacility : AbstractFacility
+	{
+		public const string IsCrossWiredIntoServiceCollectionKey = "windsor-registration-is-also-registered-in-service-collection";
+
+		protected CrossWiringComponentModelContributor crossWiringComponentModelContributor;
+
+
+		protected override void Init()
+		{
+			Kernel.ComponentModelBuilder.AddContributor(crossWiringComponentModelContributor ?? throw new InvalidOperationException("Please call `Container.AddFacility<NetCoreFacility>(f => f.CrossWiresInto(services));` first. This should happen before any cross wiring registration. Please see https://github.com/castleproject/Windsor/blob/master/docs/aspnetcore-facility.md"));
+		}
+
+		/// <summary>
+		/// Installation of the <see cref="CrossWiringComponentModelContributor"/> for registering components in both the <see cref="IWindsorContainer"/> and the <see cref="IServiceCollection"/> via the <see cref="WindsorRegistrationExtensions.CrossWired"/> component registration extension
+		/// </summary>
+		/// <param name="services"><see cref="IServiceCollection"/></param>
+		public void CrossWiresInto(IServiceCollection services)
+		{
+			crossWiringComponentModelContributor = new CrossWiringComponentModelContributor(services);
+		}
+
+
+	}
+}

--- a/src/Castle.Facilities.NetCore/Resolvers/FrameworkDependencyResolver.cs
+++ b/src/Castle.Facilities.NetCore/Resolvers/FrameworkDependencyResolver.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Facilities.AspNetCore.Resolvers
+namespace Castle.Facilities.NetCore.Resolvers
 {
 	using System;
 	using System.Linq;

--- a/src/Castle.Facilities.NetCore/Resolvers/IAcceptServiceProvider.cs
+++ b/src/Castle.Facilities.NetCore/Resolvers/IAcceptServiceProvider.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Facilities.AspNetCore.Resolvers
+namespace Castle.Facilities.NetCore.Resolvers
 {
 	using System;
 

--- a/src/Castle.Facilities.NetCore/Resolvers/LoggerDependencyResolver.cs
+++ b/src/Castle.Facilities.NetCore/Resolvers/LoggerDependencyResolver.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Facilities.AspNetCore.Resolvers
+namespace Castle.Facilities.NetCore.Resolvers
 {
 	using System;
 

--- a/src/Castle.Facilities.NetCore/WindsorContainerExtensions.cs
+++ b/src/Castle.Facilities.NetCore/WindsorContainerExtensions.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Facilities.AspNetCore
+namespace Castle.Facilities.NetCore
 {
 	using System.Linq;
 
@@ -22,7 +22,7 @@ namespace Castle.Facilities.AspNetCore
 	public static class WindsorContainerExtensions
 	{
 		/// <summary>
-		/// For grabbing a hold of the <see cref="AspNetCoreFacility"/> during middleware registration from the Configure(IApplicationBuilder, IHostingEnvironment, ILoggerFactory) method in Startup. 
+		/// For grabbing a hold of the <see cref="NetCoreFacility"/> during middleware registration from the Configure(IApplicationBuilder, IHostingEnvironment, ILoggerFactory) method in Startup. 
 		/// </summary>
 		/// <typeparam name="T">The <see cref="IFacility"/> implementation</typeparam>
 		/// <param name="container">A reference to <see cref="IWindsorContainer"/></param>

--- a/src/Castle.Facilities.NetCore/WindsorRegistrationExtensions.cs
+++ b/src/Castle.Facilities.NetCore/WindsorRegistrationExtensions.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Facilities.NetCore
+{
+	using System;
+	using System.Linq;
+
+	using Castle.Facilities.NetCore.Resolvers;
+	using Castle.MicroKernel.Lifestyle;
+	using Castle.MicroKernel.Registration;
+	using Castle.MicroKernel.Resolvers.SpecializedResolvers;
+	using Castle.Windsor;
+
+
+	using Microsoft.Extensions.DependencyInjection;
+
+	public static class WindsorRegistrationExtensions
+	{
+		/// <summary>
+		/// Sets up framework level activators for Controllers, TagHelpers and ViewComponents and adds additional sub dependency resolvers
+		/// </summary>
+		/// <param name="services"><see cref="IServiceCollection"/></param>
+		/// <param name="container"><see cref="IWindsorContainer"/></param>
+		/// <param name="configure">Configuration options for controlling registration and lifestyles of controllers, tagHelpers and viewComponents</param>
+		/// <param name="serviceProviderFactory">Optional factory for creating a custom <see cref="IServiceProvider"/></param>
+		public static IServiceProvider AddWindsor(this IServiceCollection services, IWindsorContainer container, Action<WindsorRegistrationOptions> configure = null, Func<IServiceProvider> serviceProviderFactory = null)
+		{
+			var options = new WindsorRegistrationOptions();
+			configure?.Invoke(options);
+
+			InstallWindsorIntegration(services, container);
+			return InitialiseFrameworkServiceProvider(services, serviceProviderFactory, container);
+		}
+
+		/// <summary>
+		/// For making types available to the <see cref="IServiceCollection"/> using 'late bound' factories which resolve from Windsor. This makes things like the @Inject directive in Razor work.
+		/// </summary>
+		/// <param name="registration">The component registration that gets copied across to the <see cref="IServiceCollection"/></param>
+		public static ComponentRegistration CrossWired(this ComponentRegistration registration)
+		{
+			registration.Attribute(NetCoreFacility.IsCrossWiredIntoServiceCollectionKey).Eq(Boolean.TrueString);
+			return registration;
+		}
+
+		/// <summary>
+		/// For making types available to the <see cref="IServiceCollection"/> using 'late bound' factories which resolve from Windsor. This makes things like the @Inject directive in Razor work.
+		/// </summary>
+		/// <param name="registration">The component registration that gets copied across to the IServiceCollection</param>
+		public static ComponentRegistration<T> CrossWired<T>(this ComponentRegistration<T> registration) where T : class
+		{
+			registration.Attribute(NetCoreFacility.IsCrossWiredIntoServiceCollectionKey).Eq(Boolean.TrueString);
+			return registration;
+		}
+
+
+
+
+		private static IServiceProvider InitialiseFrameworkServiceProvider(IServiceCollection services, Func<IServiceProvider> serviceProviderFactory, IWindsorContainer container)
+		{
+			var serviceProvider = serviceProviderFactory?.Invoke()?? services.BuildServiceProvider(validateScopes: false);
+			container.Register(Component.For<IServiceProvider>().Instance(serviceProvider));
+			foreach (var acceptServiceProvider in container.ResolveAll<IAcceptServiceProvider>())
+			{
+				acceptServiceProvider.AcceptServiceProvider(serviceProvider);
+			}
+			return serviceProvider;
+		}
+
+
+
+		private static void InstallWindsorIntegration(IServiceCollection services, IWindsorContainer container)
+		{
+			container.Kernel.Resolver.AddSubResolver(new ArrayResolver(container.Kernel));
+
+			var loggerDependencyResolver = new LoggerDependencyResolver();
+			container.Register(Component.For<IAcceptServiceProvider>().Instance(loggerDependencyResolver));
+			container.Kernel.Resolver.AddSubResolver(loggerDependencyResolver);
+
+			var frameworkDependencyResolver = new FrameworkDependencyResolver(services);
+			container.Register(Component.For<IAcceptServiceProvider>().Instance(frameworkDependencyResolver));
+			container.Kernel.Resolver.AddSubResolver(frameworkDependencyResolver);
+		}
+	}
+}

--- a/src/Castle.Facilities.NetCore/WindsorRegistrationOptions.cs
+++ b/src/Castle.Facilities.NetCore/WindsorRegistrationOptions.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Facilities.AspNetCore
+namespace Castle.Facilities.NetCore
 {
 	using System.Collections.Generic;
 	using System.Reflection;
@@ -27,7 +27,7 @@ namespace Castle.Facilities.AspNetCore
 	{
 		private Assembly entryAssembly = null;
 
-		internal Assembly EntryAssembly
+		public  Assembly EntryAssembly
 		{
 			get
 			{
@@ -44,13 +44,13 @@ namespace Castle.Facilities.AspNetCore
 			}
 		}
 
-		internal List<(Assembly, LifestyleType)> ControllerAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
-		internal List<(Assembly, LifestyleType)> TagHelperAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
-		internal List<(Assembly, LifestyleType)> ViewComponentAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
+		public List<(Assembly, LifestyleType)> ControllerAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
+		public List<(Assembly, LifestyleType)> TagHelperAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
+		public List<(Assembly, LifestyleType)> ViewComponentAssemblyRegistrations = new List<(Assembly, LifestyleType)>();
 
-		internal List<IRegistration> ControllerComponentRegistrations = new List<IRegistration>();
-		internal List<IRegistration> TagHelperComponentRegistrations = new List<IRegistration>();
-		internal List<IRegistration> ViewComponentComponentRegistrations = new List<IRegistration>();
+		public List<IRegistration> ControllerComponentRegistrations = new List<IRegistration>();
+		public List<IRegistration> TagHelperComponentRegistrations = new List<IRegistration>();
+		public List<IRegistration> ViewComponentComponentRegistrations = new List<IRegistration>();
 
 		/// <summary>
 		/// Use this method to specify where controllers, tagHelpers and viewComponents are registered from. Use this method


### PR DESCRIPTION
… configuration options.
See issue: castleproject/Windsor#487

As a start I basically separated the functionality into two facilities: NetCoreFacility & AspNetCoreFacitlity.

I first renamed the original project to NetCore, threw out all AspeNetCore dependent code.
Then I added the original project again and removed the double definitions.
I had to make some properties more accesible to make sure all code still worked.


So if you want to use Windsor in an non-web application, you no longer are required to include AspNetCore packages.

More work is needed to further clean up and separte the documentation.

Could someone review this already perhaps. I'll try to continue to send further updates.
