### PR TITLE
AspNetCore Facility bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 Bugfixes:
+- ASP.NET Core Facility: Allow crosswiring multiple implementations of the same service
+- ASP.NET Core Facility: Count TagHelper classes with __Generated__ in the name (eg. TagHelpers generated for ViewComponents) as Framework classes
 - Finding the controller should be made in a case insensitive way for Castle.Facilities.AspNet.Mvc facility (@yitzchok, #480)
 
 ## 5.0.0 (2019-02-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Bugfixes:
+- ASP.NET Core Facility: FrameworkDependencyResolver must not throw NRE if dependency has no type (eg. depending on a named component)
 - ASP.NET Core Facility: Register ViewComponents and TagHelpers correctly
 - ASP.NET Core Facility: Allow crosswiring multiple implementations of the same service
 - ASP.NET Core Facility: Count TagHelper classes with __Generated__ in the name (eg. TagHelpers generated for ViewComponents) as Framework classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Bugfixes:
+- ASP.NET Core Facility: Register ViewComponents and TagHelpers correctly
 - ASP.NET Core Facility: Allow crosswiring multiple implementations of the same service
 - ASP.NET Core Facility: Count TagHelper classes with __Generated__ in the name (eg. TagHelpers generated for ViewComponents) as Framework classes
 - Finding the controller should be made in a case insensitive way for Castle.Facilities.AspNet.Mvc facility (@yitzchok, #480)

--- a/src/Castle.Facilities.AspNetCore.Tests/Fakes/AuthorisationHandler.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Fakes/AuthorisationHandler.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Castle.Facilities.AspNetCore.Tests.Fakes
+{
+	public class AuthorisationHandlerOne : IAuthorizationHandler
+	{
+		public Task HandleAsync(AuthorizationHandlerContext context)
+		{
+			return Task.CompletedTask;
+		}
+	}
+
+	public class AuthorisationHandlerTwo : IAuthorizationHandler
+	{
+		public Task HandleAsync(AuthorizationHandlerContext context)
+		{
+			return Task.CompletedTask;
+		}
+	}
+
+	public class AuthorisationHandlerThree : IAuthorizationHandler
+	{
+		public Task HandleAsync(AuthorizationHandlerContext context)
+		{
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Castle.Facilities.AspNetCore.Tests/Resolvers/FrameworkDependencyResolverTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/Resolvers/FrameworkDependencyResolverTestCase.cs
@@ -44,6 +44,12 @@ namespace Castle.Facilities.AspNetCore.Tests.Resolvers
 			testContext.Dispose();
 		}
 
+		[Test]
+		public void Should_not_match_null()
+		{
+			Assert.That(frameworkDependencyResolver.HasMatchingType(null), Is.False);
+		}
+
 		[TestCase(typeof(ServiceProviderOnlyTransient))]
 		[TestCase(typeof(ServiceProviderOnlyTransientGeneric<OpenOptions>))]
 		[TestCase(typeof(ServiceProviderOnlyTransientGeneric<ClosedOptions>))]

--- a/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationExtensionsTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationExtensionsTestCase.cs
@@ -15,6 +15,7 @@
 namespace Castle.Facilities.AspNetCore.Tests
 {
 	using System;
+	using System.Linq;
 
 	using Castle.Core;
 	using Castle.Facilities.AspNetCore.Tests.Fakes;
@@ -286,6 +287,22 @@ namespace Castle.Facilities.AspNetCore.Tests
 					sp.GetRequiredService(compositeType);
 				}
 			});
+		}
+
+		[Test]
+		public void Should_resolve_Multiple_Transient_CrossWired_from_ServiceProvider()
+		{
+			testContext.WindsorContainer.Register(Types.FromAssemblyContaining<AuthorisationHandlerOne>()
+				.BasedOn<Microsoft.AspNetCore.Authorization.IAuthorizationHandler>().WithServiceBase()
+				.LifestyleTransient().Configure(c => c.CrossWired()));
+
+			using (var sp = testContext.ServiceCollection.BuildServiceProvider())
+			{
+				var services = sp.GetServices<Microsoft.AspNetCore.Authorization.IAuthorizationHandler>();
+
+				Assert.That(services, Has.Exactly(3).Items);
+				Assert.That(services.Select(s => s.GetType()), Is.Unique);
+			}
 		}
 
 		[TestCase(LifestyleType.Bound)]

--- a/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsControllerTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsControllerTestCase.cs
@@ -20,11 +20,10 @@ namespace Castle.Facilities.AspNetCore.Tests
 	using Castle.MicroKernel.Registration;
 
 	using Microsoft.AspNetCore.Mvc;
-	using Microsoft.AspNetCore.Razor.TagHelpers;
 
 	using NUnit.Framework;
 
-	public abstract class WindsorRegistrationOptionsTestCase
+	public abstract class WindsorRegistrationOptionsControllerTestCase
 	{
 		[SetUp]
 		public abstract void SetUp();
@@ -37,52 +36,38 @@ namespace Castle.Facilities.AspNetCore.Tests
 
 		protected Framework.TestContext testContext;
 
-		[TestCase(typeof(OverrideTagHelper))]
 		[TestCase(typeof(OverrideController))]
-		[TestCase(typeof(OverrideViewComponent))]
-		public void Should_resolve_overidden_Controllers_TagHelpers_and_ViewComponents_using_WindsorRegistrationOptions(Type optionsResolvableType)
+		public void Should_resolve_overidden_Controllers_using_WindsorRegistrationOptions(Type optionsResolvableType)
 		{
 			Assert.DoesNotThrow(() => { testContext.WindsorContainer.Resolve(optionsResolvableType); });
-		}
-
-		public class OverrideTagHelper : TagHelper
-		{
 		}
 
 		public class OverrideController : Controller
 		{
 		}
-
-		public class OverrideViewComponent : ViewComponent
-		{
-		}
 	}
 
 	[TestFixture]
-	public class WindsorRegistrationOptionsForAssembliesTestCase : WindsorRegistrationOptionsTestCase
+	public class WindsorRegistrationOptionsForAssembliesControllerTestCase : WindsorRegistrationOptionsControllerTestCase
 	{
 		[SetUp]
 		public override void SetUp()
 		{
 			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(typeof(OverrideTagHelper).Assembly)
-				.RegisterControllers(typeof(OverrideController).Assembly)
-				.RegisterViewComponents(typeof(OverrideViewComponent).Assembly));
+				.UseEntryAssembly(typeof(Uri).Assembly)
+				.RegisterControllers(typeof(OverrideController).Assembly));
 		}
 	}
 
 	[TestFixture]
-	public class WindsorRegistrationOptionsForComponentsTestCase : WindsorRegistrationOptionsTestCase
+	public class WindsorRegistrationOptionsForComponentsControllerTestCase : WindsorRegistrationOptionsControllerTestCase
 	{
 		[SetUp]
 		public override void SetUp()
 		{
 			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(Component.For<OverrideTagHelper>().LifestyleScoped().Named("tag-helpers"))
-				.RegisterControllers(Component.For<OverrideController>().LifestyleScoped().Named("controllers"))
-				.RegisterViewComponents(Component.For<OverrideViewComponent>().LifestyleScoped().Named("view-components")));
+				.UseEntryAssembly(typeof(Uri).Assembly)
+				.RegisterControllers(Component.For<OverrideController>().LifestyleScoped().Named("controllers")));
 		}
 	}
 }

--- a/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsTagHelperTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsTagHelperTestCase.cs
@@ -19,12 +19,11 @@ namespace Castle.Facilities.AspNetCore.Tests
 	using Castle.Facilities.AspNetCore.Tests.Framework;
 	using Castle.MicroKernel.Registration;
 
-	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Razor.TagHelpers;
 
 	using NUnit.Framework;
 
-	public abstract class WindsorRegistrationOptionsTestCase
+	public abstract class WindsorRegistrationOptionsTagHelperTestCase
 	{
 		[SetUp]
 		public abstract void SetUp();
@@ -38,9 +37,7 @@ namespace Castle.Facilities.AspNetCore.Tests
 		protected Framework.TestContext testContext;
 
 		[TestCase(typeof(OverrideTagHelper))]
-		[TestCase(typeof(OverrideController))]
-		[TestCase(typeof(OverrideViewComponent))]
-		public void Should_resolve_overidden_Controllers_TagHelpers_and_ViewComponents_using_WindsorRegistrationOptions(Type optionsResolvableType)
+		public void Should_resolve_overidden_TagHelpers_using_WindsorRegistrationOptions(Type optionsResolvableType)
 		{
 			Assert.DoesNotThrow(() => { testContext.WindsorContainer.Resolve(optionsResolvableType); });
 		}
@@ -48,41 +45,29 @@ namespace Castle.Facilities.AspNetCore.Tests
 		public class OverrideTagHelper : TagHelper
 		{
 		}
-
-		public class OverrideController : Controller
-		{
-		}
-
-		public class OverrideViewComponent : ViewComponent
-		{
-		}
 	}
 
 	[TestFixture]
-	public class WindsorRegistrationOptionsForAssembliesTestCase : WindsorRegistrationOptionsTestCase
+	public class WindsorRegistrationOptionsForAssembliesTagHelperTestCase : WindsorRegistrationOptionsTagHelperTestCase
 	{
 		[SetUp]
 		public override void SetUp()
 		{
 			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(typeof(OverrideTagHelper).Assembly)
-				.RegisterControllers(typeof(OverrideController).Assembly)
-				.RegisterViewComponents(typeof(OverrideViewComponent).Assembly));
+				.UseEntryAssembly(typeof(Uri).Assembly)
+				.RegisterTagHelpers(typeof(OverrideTagHelper).Assembly));
 		}
 	}
 
 	[TestFixture]
-	public class WindsorRegistrationOptionsForComponentsTestCase : WindsorRegistrationOptionsTestCase
+	public class WindsorRegistrationOptionsForComponentsTagHelperTestCase : WindsorRegistrationOptionsTagHelperTestCase
 	{
 		[SetUp]
 		public override void SetUp()
 		{
 			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(Component.For<OverrideTagHelper>().LifestyleScoped().Named("tag-helpers"))
-				.RegisterControllers(Component.For<OverrideController>().LifestyleScoped().Named("controllers"))
-				.RegisterViewComponents(Component.For<OverrideViewComponent>().LifestyleScoped().Named("view-components")));
+				.UseEntryAssembly(typeof(Uri).Assembly)
+				.RegisterTagHelpers(Component.For<OverrideTagHelper>().LifestyleScoped().Named("tag-helpers")));
 		}
 	}
 }

--- a/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsViewComponentTestCase.cs
+++ b/src/Castle.Facilities.AspNetCore.Tests/WindsorRegistrationOptionsViewComponentTestCase.cs
@@ -20,11 +20,10 @@ namespace Castle.Facilities.AspNetCore.Tests
 	using Castle.MicroKernel.Registration;
 
 	using Microsoft.AspNetCore.Mvc;
-	using Microsoft.AspNetCore.Razor.TagHelpers;
 
 	using NUnit.Framework;
 
-	public abstract class WindsorRegistrationOptionsTestCase
+	public abstract class WindsorRegistrationOptionsViewComponentTestCase
 	{
 		[SetUp]
 		public abstract void SetUp();
@@ -37,20 +36,10 @@ namespace Castle.Facilities.AspNetCore.Tests
 
 		protected Framework.TestContext testContext;
 
-		[TestCase(typeof(OverrideTagHelper))]
-		[TestCase(typeof(OverrideController))]
 		[TestCase(typeof(OverrideViewComponent))]
-		public void Should_resolve_overidden_Controllers_TagHelpers_and_ViewComponents_using_WindsorRegistrationOptions(Type optionsResolvableType)
+		public void Should_resolve_overidden_ViewComponents_using_WindsorRegistrationOptions(Type optionsResolvableType)
 		{
 			Assert.DoesNotThrow(() => { testContext.WindsorContainer.Resolve(optionsResolvableType); });
-		}
-
-		public class OverrideTagHelper : TagHelper
-		{
-		}
-
-		public class OverrideController : Controller
-		{
 		}
 
 		public class OverrideViewComponent : ViewComponent
@@ -59,29 +48,25 @@ namespace Castle.Facilities.AspNetCore.Tests
 	}
 
 	[TestFixture]
-	public class WindsorRegistrationOptionsForAssembliesTestCase : WindsorRegistrationOptionsTestCase
+	public class WindsorRegistrationOptionsForAssembliesViewComponentTestCase : WindsorRegistrationOptionsViewComponentTestCase
 	{
 		[SetUp]
 		public override void SetUp()
 		{
 			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(typeof(OverrideTagHelper).Assembly)
-				.RegisterControllers(typeof(OverrideController).Assembly)
+				.UseEntryAssembly(typeof(Uri).Assembly)
 				.RegisterViewComponents(typeof(OverrideViewComponent).Assembly));
 		}
 	}
 
 	[TestFixture]
-	public class WindsorRegistrationOptionsForComponentsTestCase : WindsorRegistrationOptionsTestCase
+	public class WindsorRegistrationOptionsForComponentsViewComponentTestCase : WindsorRegistrationOptionsViewComponentTestCase
 	{
 		[SetUp]
 		public override void SetUp()
 		{
 			testContext = TestContextFactory.Get(opts => opts
-				.UseEntryAssembly(typeof(WindsorRegistrationOptionsTestCase).Assembly)
-				.RegisterTagHelpers(Component.For<OverrideTagHelper>().LifestyleScoped().Named("tag-helpers"))
-				.RegisterControllers(Component.For<OverrideController>().LifestyleScoped().Named("controllers"))
+				.UseEntryAssembly(typeof(Uri).Assembly)
 				.RegisterViewComponents(Component.For<OverrideViewComponent>().LifestyleScoped().Named("view-components")));
 		}
 	}

--- a/src/Castle.Facilities.AspNetCore/AspNetCoreMvcExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/AspNetCoreMvcExtensions.cs
@@ -49,7 +49,8 @@ namespace Castle.Facilities.AspNetCore
 			if (services == null) throw new ArgumentNullException(nameof(services));
 			if (activator == null) throw new ArgumentNullException(nameof(activator));
 
-			applicationTypeSelector = applicationTypeSelector ?? (type => !type.GetTypeInfo().Namespace.StartsWith("Microsoft"));
+			applicationTypeSelector = applicationTypeSelector ?? (type => !type.GetTypeInfo().Namespace.StartsWith("Microsoft") &&
+																	!type.GetTypeInfo().Name.Contains("__Generated__"));
 
 			services.AddSingleton<ITagHelperActivator>(provider =>
 				new DelegatingTagHelperActivator(

--- a/src/Castle.Facilities.AspNetCore/Contributors/CrossWiringComponentModelContributor.cs
+++ b/src/Castle.Facilities.AspNetCore/Contributors/CrossWiringComponentModelContributor.cs
@@ -49,26 +49,25 @@ namespace Castle.Facilities.AspNetCore.Contributors
 					}
 				}
 
+				var key = model.Name;
+
 				foreach (var serviceType in model.Services)
 				{
 					if (model.LifestyleType == LifestyleType.Transient)
 					{
-						services.AddTransient(serviceType, p =>
-						{
-							return kernel.Resolve(serviceType);
-						});
+						services.AddTransient(serviceType, p => kernel.Resolve(key, serviceType));
 					}
 					else if (model.LifestyleType == LifestyleType.Scoped)
 					{
 						services.AddScoped(serviceType, p =>
 						{
 							kernel.RequireScope();
-							return kernel.Resolve(serviceType);
+							return kernel.Resolve(key, serviceType);
 						});
 					}
 					else if (model.LifestyleType == LifestyleType.Singleton)
 					{
-						services.AddSingleton(serviceType, p => kernel.Resolve(serviceType));
+						services.AddSingleton(serviceType, p => kernel.Resolve(key, serviceType));
 					}
 					else
 					{

--- a/src/Castle.Facilities.AspNetCore/Resolvers/FrameworkDependencyResolver.cs
+++ b/src/Castle.Facilities.AspNetCore/Resolvers/FrameworkDependencyResolver.cs
@@ -51,7 +51,8 @@ namespace Castle.Facilities.AspNetCore.Resolvers
 
 		public bool HasMatchingType(Type dependencyType)
 		{
-			return serviceCollection.Any(x => x.ServiceType.MatchesType(dependencyType));
+			return dependencyType != null &&
+				serviceCollection.Any(x => x.ServiceType.MatchesType(dependencyType));
 		}
 
 		private void ThrowIfServiceProviderIsNull()
@@ -69,7 +70,7 @@ namespace Castle.Facilities.AspNetCore.Resolvers
 		{
 			var genericType = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
 			var genericOtherType = otherType.IsGenericType ? otherType.GetGenericTypeDefinition() : otherType;
-			return genericType == genericOtherType || genericOtherType == genericType;
+			return genericType == genericOtherType;
 		}
 	}
 }

--- a/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
+++ b/src/Castle.Facilities.AspNetCore/WindsorRegistrationExtensions.cs
@@ -102,12 +102,12 @@ namespace Castle.Facilities.AspNetCore
 
 			if (!options.TagHelperAssemblyRegistrations.Any() && !options.TagHelperComponentRegistrations.Any())
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ViewComponent>().LifestyleScoped());
+				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ITagHelper>().LifestyleScoped());
 			}
 
 			if (!options.ViewComponentAssemblyRegistrations.Any() && !options.ViewComponentComponentRegistrations.Any())
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ITagHelper>().LifestyleScoped());
+				container.Register(Classes.FromAssemblyInThisApplication(options.EntryAssembly).BasedOn<ViewComponent>().LifestyleScoped());
 			}
 
 			// Assembly registrations
@@ -117,14 +117,14 @@ namespace Castle.Facilities.AspNetCore
 				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<ControllerBase>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
 			}
 
-			foreach (var controllerRegistration in options.TagHelperAssemblyRegistrations)
+			foreach (var tagHelperRegistration in options.TagHelperAssemblyRegistrations)
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<ViewComponent>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
+				container.Register(Classes.FromAssemblyInThisApplication(tagHelperRegistration.Item1).BasedOn<ITagHelper>().Configure(x => x.LifeStyle.Is(tagHelperRegistration.Item2)));
 			}
 
-			foreach (var controllerRegistration in options.ViewComponentAssemblyRegistrations)
+			foreach (var viewComponentRegistration in options.ViewComponentAssemblyRegistrations)
 			{
-				container.Register(Classes.FromAssemblyInThisApplication(controllerRegistration.Item1).BasedOn<ITagHelper>().Configure(x => x.LifeStyle.Is(controllerRegistration.Item2)));
+				container.Register(Classes.FromAssemblyInThisApplication(viewComponentRegistration.Item1).BasedOn<ViewComponent>().Configure(x => x.LifeStyle.Is(viewComponentRegistration.Item2)));
 			}
 
 			// Component registrations


### PR DESCRIPTION
Some small fixes that have helped me use the AspNetCore facility with aspnet core 2.2.
To allow resolving multiple implementations of the same service correctly, capture the ComponentName and use as key in the register factories.
TagHelpers automatically generated for ViewComponents were not being resolved from the framework container because the namespace doesnot begin with Microsoft.
Fixed registration of TagHelpers and ViewComponents - they were mixed up.
Fixes #478 