### PR TITLE
DefaultComponentActivator sets nonpublic props too

### DIFF
--- a/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
+++ b/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
@@ -314,7 +314,7 @@ namespace Castle.MicroKernel.ComponentActivator
 					continue;
 				}
 
-				var setMethod = property.Property.GetSetMethod();
+				var setMethod = property.Property.GetSetMethod(nonPublic: true);
 				try
 				{
 					setMethod.Invoke(instance, new[] { value });


### PR DESCRIPTION
The reason is that it is the model's decision what properties should be injected, not activator's. By default, model excludes non-public properties. But if some customization was applied that requested injecting through non-public setter - now it requires providing a custom activator, which is not trivial to write and use (e.g. you need to select the activator for your components correctly).