### PR TITLE
Update some outdated docs in the readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,7 @@ Castle Windsor is best of breed, mature [Inversion of Control container](ioc.md)
 
 * See [the release notes](https://github.com/castleproject/Windsor/releases/latest)
 * [Download it](https://github.com/castleproject/Windsor/releases/latest)
-* Get official builds from [NuGet](http://nuget.org/packages/Castle.Windsor): `PM> Install-Package Castle.Windsor`
-* Or [get pre-release packages as they're built](https://github.com/castleproject/Home/blob/master/prerelease-packages.md)
+* Get official and pre-release builds from [NuGet](http://nuget.org/packages/Castle.Windsor): `PM> Install-Package Castle.Windsor`
 
 ## Show me the code already
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,8 @@
 
 Castle Windsor is best of breed, mature [Inversion of Control container](ioc.md) available for .NET.
 
-* See [the release notes](https://github.com/castleproject/Windsor/releases/tag/v3.3)
-* [Download it](https://github.com/castleproject/Windsor/releases/tag/v3.3)
+* See [the release notes](https://github.com/castleproject/Windsor/releases/latest)
+* [Download it](https://github.com/castleproject/Windsor/releases/latest)
 * Get official builds from [NuGet](http://nuget.org/packages/Castle.Windsor): `PM> Install-Package Castle.Windsor`
 * Or [get pre-release packages as they're built](https://github.com/castleproject/Home/blob/master/prerelease-packages.md)
 


### PR DESCRIPTION
The readme file had a few outdated URLs. Specifically it was linking to v3.3 as the latest release and also featured a prominent link to the TeamCity server that's no longer used.

I updated the release URL to use the `latest` tag and removed the pre-release bullet.