### PR TITLE
Clarified documentation for Castle.Windsor.Extensions.DependencyInjection

### DIFF
--- a/docs/net-dependency-extension.md
+++ b/docs/net-dependency-extension.md
@@ -27,6 +27,9 @@ Because there are subtle differences between .NET and Castle Windsor lifestyle s
 | Singleton | Only one instance ever exists and it's disposed once outermost `IServiceProvider` is disposed (usually application shutdown). |
 
 ## What do I need to set it up?
+### Using the .NET lifestyle semantics
+All services injected into controllers will have to be registered with the lifestyles described in "Services lifestyle"
+
 1. Add `Castle.Windsor.Extensions.DependencyInjection` package to your application.
 2. Add `UseWindsorContainerServiceProvider()` when creating the Host
     ```
@@ -34,6 +37,22 @@ Because there are subtle differences between .NET and Castle Windsor lifestyle s
          .UseWindsorContainerServiceProvider()
     ```
     This will register an `IServiceProviderFactory`
-2. Any services registred in `Startup.ConfigureServices` will be registered with `IWindsorContainer`. No need to cross-wire since `IWindsorContainer` is the only `IServiceProvider`
+2. Any services registered in `Startup.ConfigureServices` will be registered with `IWindsorContainer`. No need to cross-wire since `IWindsorContainer` is the only `IServiceProvider`
 4. To access the container directly inject either `IWindsorContainer` or `IServiceProvider`
+
+### Using the Castle Windsor lifestyle semantics
+
+This will allow you to leave your existing Castle Windsor registrations untouched.
+
+Using .NET lifestyle semantics, any service using the Castle Windsor transient lifestyle, and directly injected into the controller, will not be released.
+To allow the standard Windsor behavior for services directly injected in the controllers, you will have to allow Castle Windsor to resolve and release the controllers.
+To do that add AddControllerAsServices to the call to ConfigureServices in your Startup class:
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services
+            .AddControllers()
+            .AddControllersAsServices();
+    }
+
 


### PR DESCRIPTION
Documenting a solution for issue #530 

Following the documentation it is possible to use the DependencyInjection extension for .NET Core 3.x and higher and maintain the behavior of Castle Windsor lifestyles.