### PR TITLE
Fix components being cleared when registering existing container in host

### DIFF
--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Components/EmptyService.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Components/EmptyService.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2004-2020 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests.Components
+{
+	public class EmptyService : IEmptyService
+	{
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Components/IEmptyService.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Components/IEmptyService.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2004-2020 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests.Components
+{
+	public interface IEmptyService
+	{
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Extensions/HostBuilderExtensionsTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Extensions/HostBuilderExtensionsTests.cs
@@ -26,18 +26,18 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests.Extensions
 		[Fact]
 		public void ServicesCanBeResolvedAfterServiceRegistrationInHost()
 		{
-			var container = new WindsorContainer();
-			container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyService>());
+			using (var container = new WindsorContainer())
+			{
+				container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyService>());
 
-			new HostBuilder()
-				.UseWindsorContainerServiceProvider(container)
-				.Build();
+				new HostBuilder()
+					.UseWindsorContainerServiceProvider(container)
+					.Build();
 
-			var service = container.Resolve<IEmptyService>();
+				var service = container.Resolve<IEmptyService>();
 
-			Assert.NotNull(service);
-
-			container.Dispose();
+				Assert.NotNull(service);
+			}
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Extensions/HostBuilderExtensionsTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Extensions/HostBuilderExtensionsTests.cs
@@ -36,6 +36,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests.Extensions
 			var service = container.Resolve<IEmptyService>();
 
 			Assert.NotNull(service);
+
+			container.Dispose();
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Extensions/HostBuilderExtensionsTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Extensions/HostBuilderExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2004-2020 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests.Extensions
+{
+	using Castle.MicroKernel.Registration;
+	using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
+
+	using Microsoft.Extensions.Hosting;
+
+	using Xunit;
+
+	public class HostBuilderExtensionsTests
+	{
+		[Fact]
+		public void ServicesCanBeResolvedAfterServiceRegistrationInHost()
+		{
+			var container = new WindsorContainer();
+			container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyService>());
+
+			new HostBuilder()
+				.UseWindsorContainerServiceProvider(container)
+				.Build();
+
+			var service = container.Resolve<IEmptyService>();
+
+			Assert.NotNull(service);
+		}
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorServiceProviderFactoryTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorServiceProviderFactoryTests.cs
@@ -24,16 +24,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		[Fact]
 		public void ServicesCanBeResolvedAfterServiceProviderCreated()
 		{
-			var container = new WindsorContainer();
-			container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyService>());
+			using (var container = new WindsorContainer())
+			{
+				container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyService>());
 
-			var _ = new WindsorServiceProviderFactory(container);
+				var _ = new WindsorServiceProviderFactory(container);
 			
-			var service = container.Resolve<IEmptyService>();
+				var service = container.Resolve<IEmptyService>();
 
-			Assert.NotNull(service);
-
-			container.Dispose();
+				Assert.NotNull(service);
+			}
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorServiceProviderFactoryTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorServiceProviderFactoryTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2004-2020 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests
+{
+	using Castle.MicroKernel.Registration;
+	using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
+
+	using Xunit;
+
+	public class WindsorServiceProviderFactoryTests
+	{
+		[Fact]
+		public void ServicesCanBeResolvedAfterServiceProviderCreated()
+		{
+			var container = new WindsorContainer();
+			container.Register(Component.For<IEmptyService>().ImplementedBy<EmptyService>());
+
+			var _ = new WindsorServiceProviderFactory(container);
+			
+			var service = container.Resolve<IEmptyService>();
+
+			Assert.NotNull(service);
+		}
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorServiceProviderFactoryTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorServiceProviderFactoryTests.cs
@@ -32,6 +32,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var service = container.Resolve<IEmptyService>();
 
 			Assert.NotNull(service);
+
+			container.Dispose();
 		}
 	}
 }

--- a/src/Castle.Windsor/MicroKernel/DefaultKernel.cs
+++ b/src/Castle.Windsor/MicroKernel/DefaultKernel.cs
@@ -342,7 +342,17 @@ namespace Castle.MicroKernel
 			}
 			else if (name == SubSystemConstants.NamingKey)
 			{
-				NamingSubSystem = (INamingSubSystem)subsystem;
+				var namingSubSystem = subsystem as INamingSubSystem;
+
+				if (NamingSubSystem != null)
+				{
+					foreach (var handler in NamingSubSystem.GetAllHandlers())
+					{
+						namingSubSystem?.Register(handler);
+					}
+				}
+
+				NamingSubSystem = namingSubSystem;
 			}
 		}
 


### PR DESCRIPTION
Fixes #550 

My quick and dirty fix is just to copy the existing handlers from the old naming subsystem to the new one. Not sure if its the right fix, but hopefully this illustrates the issue.