### PR TITLE
Use generic registration instead of reflection

### DIFF
--- a/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/ServiceDescriptorExtensions.cs
@@ -14,8 +14,6 @@
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 {
-	using System.Reflection;
-
 	using Castle.MicroKernel.Registration;
 
 	public static class ServiceDescriptorExtensions
@@ -26,11 +24,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 			{
 				return RegistrationAdapter.FromOpenGenericServiceDescriptor(service);
 			}
-			else
-			{
-				var method = typeof(RegistrationAdapter).GetMethod("FromServiceDescriptor", BindingFlags.Static | BindingFlags.Public).MakeGenericMethod(service.ServiceType);
-				return method.Invoke(null, new object[] { service }) as IRegistration;
-			}
+
+			return RegistrationAdapter.FromServiceDescriptor(service);
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -41,25 +41,25 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 				.IsDefault();
 		}
 
-		public static IRegistration FromServiceDescriptor<TService>(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		public static IRegistration FromServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
 		{
-			var registration = Component.For<TService>()
+			var registration = Component.For(service.ServiceType)
 				.NamedAutomatically(UniqueComponentName(service));
 
-			if(service.ImplementationFactory != null)
+			if (service.ImplementationFactory != null)
 			{
-				registration = UsingFactoryMethod<TService>(registration, service);
+				registration = UsingFactoryMethod(registration, service);
 			}
-			else if(service.ImplementationInstance != null)
+			else if (service.ImplementationInstance != null)
 			{
-				registration = UsingInstance<TService>(registration, service);
+				registration = UsingInstance(registration, service);
 			}
-			else if(service.ImplementationType != null)
+			else if (service.ImplementationType != null)
 			{
-				registration = UsingImplementation<TService>(registration, service);
+				registration = UsingImplementation(registration, service);
 			}
 
-			return ResolveLifestyle<TService>(registration, service)
+			return ResolveLifestyle(registration, service)
 				.IsDefault();
 		}
 


### PR DESCRIPTION
Components will be of type `Component<object>` instead. This would supersede the change in https://github.com/castleproject/Windsor/pull/553.