### PR TITLE
Should use the container from the method call, not the root container

### DIFF
--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorServiceProviderFactoryBase.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorServiceProviderFactoryBase.cs
@@ -60,7 +60,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 		protected virtual void AddSubSystemToContainer(IWindsorContainer container)
 		{
-			rootContainer.Kernel.AddSubSystem(
+			container.Kernel.AddSubSystem(
 				SubSystemConstants.NamingKey,
 				new SubSystems.DependencyInjectionNamingSubsystem()
 			);


### PR DESCRIPTION
Should use the container from the method call, not the root container

#557