### PR TITLE
Allow DefaultNamingSubSystem derivatives to invalidate the cache

### DIFF
--- a/src/Castle.Windsor/MicroKernel/SubSystems/Naming/DefaultNamingSubSystem.cs
+++ b/src/Castle.Windsor/MicroKernel/SubSystems/Naming/DefaultNamingSubSystem.cs
@@ -345,7 +345,7 @@ namespace Castle.MicroKernel.SubSystems.Naming
 			return null;
 		}
 
-		private void InvalidateCache()
+		protected void InvalidateCache()
 		{
 			handlerListsByTypeCache.Clear();
 			assignableHandlerListsByTypeCache.Clear();


### PR DESCRIPTION
Undo breaking change from
https://github.com/castleproject/Windsor/pull/556/files#diff-abfeffa5864abf0d2f22d3a8eb387e9742a306bb7309ad528b044b78da178b45

Related Issue #566