### PR TITLE
Fix XML configuration dictionary containing list of components throws exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bugfixes:
 - Fix CollectionResolver to allow propagation of inline dependencies (@dvdwouwe, #562)
 - Allow DefaultNamingSubSystem derivatives to invalidate the cache which was accidently removed in 5.1.0 (@nativenolde, #569)
+- Fix dictionary bug where reference to list components didn't work (@ni-mi, #575)
 
 ## 5.1.0 (2020-11-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Bugfixes:
 - Fix CollectionResolver to allow propagation of inline dependencies (@dvdwouwe, #562)
 - Allow DefaultNamingSubSystem derivatives to invalidate the cache which was accidently removed in 5.1.0 (@nativenolde, #569)
 - Replace usage of obsolete Castle.Core.Internal.Lock (@generik0, #576)
-- Fix dictionary bug where reference to list components didn't work (@ni-mi, #575)
+- Fix dictionary bug when using XML configuration; A reference to list components inside a dictionary didn't work (@ni-mi, #575)
 
 ## 5.1.0 (2020-11-16)
 

--- a/src/Castle.Windsor.Tests/Config/ConfigurationTestCase.cs
+++ b/src/Castle.Windsor.Tests/Config/ConfigurationTestCase.cs
@@ -35,9 +35,6 @@ namespace Castle.MicroKernel.Tests.Configuration
 	[TestFixture]
 	public class ConfigurationTestCase : AbstractContainerTestCase
 	{
-		
-		
-		
 		[Test]
 		[Bug("https://github.com/castleproject/Windsor/issues/574")]
 		public void DictionaryWithReferencedProperty()
@@ -70,7 +67,6 @@ namespace Castle.MicroKernel.Tests.Configuration
 			Assert.AreEqual("Property Value 1", stringToStringDictionary["Key 1"]);
 			Assert.AreEqual("Property Value 2", stringToStringDictionary["Key 2"]);
 		}
-		
 		
 		[Test]
 		[Bug("https://github.com/castleproject/Windsor/issues/574")]
@@ -123,10 +119,7 @@ namespace Castle.MicroKernel.Tests.Configuration
 			Assert.NotNull(stringToListDictionary);
 			Assert.AreEqual(2, stringToListDictionary.Count);
 		}
-		
-		
-		
-		
+
 		[Test]
 		[Bug("IOC-155")]
 		public void Type_not_implementing_service_should_throw()
@@ -221,7 +214,6 @@ namespace Castle.MicroKernel.Tests.Configuration
 			var user = Container.Resolve<UsesIEmptyService>();
 			Assert.NotNull(user.EmptyService);
 		}
-
 
 		[Test]
 		public void Can_properly_populate_array_dependency_from_xml_config_when_registering_by_convention()

--- a/src/Castle.Windsor.Tests/Config/ConfigurationTestCase.cs
+++ b/src/Castle.Windsor.Tests/Config/ConfigurationTestCase.cs
@@ -38,6 +38,39 @@ namespace Castle.MicroKernel.Tests.Configuration
 		
 		
 		
+		[Test]
+		[Bug("https://github.com/castleproject/Windsor/issues/574")]
+		public void DictionaryWithReferencedProperty()
+		{
+			var config =
+				@"
+<configuration>
+	<properties>
+		<value1>Property Value 1</value1>
+        <value2>Property Value 2</value2>
+    </properties>
+	<components>
+				<component id='stringToStringDictionary' type='System.Collections.Generic.Dictionary`2[System.String, System.String]'>
+					<parameters>
+						<dictionary>
+							<dictionary>
+								<entry key='Key 1'>#{value1}</entry>
+								<entry key='Key 2'>#{value2}</entry>
+							</dictionary>
+						</dictionary>
+					</parameters>
+				</component>
+	</components>
+</configuration>";
+
+			Container.Install(Configuration.FromXml(new StaticContentResource(config)));
+			var stringToStringDictionary = Container.Resolve<Dictionary<string, string>>("stringToStringDictionary");
+			Assert.NotNull(stringToStringDictionary);
+			Assert.AreEqual(2, stringToStringDictionary.Count);
+			Assert.AreEqual("Property Value 1", stringToStringDictionary["Key 1"]);
+			Assert.AreEqual("Property Value 2", stringToStringDictionary["Key 2"]);
+		}
+		
 		
 		[Test]
 		[Bug("https://github.com/castleproject/Windsor/issues/574")]

--- a/src/Castle.Windsor.Tests/Config/ConfigurationTestCase.cs
+++ b/src/Castle.Windsor.Tests/Config/ConfigurationTestCase.cs
@@ -14,6 +14,8 @@
 
 namespace Castle.MicroKernel.Tests.Configuration
 {
+	using System.Collections.Generic;
+
 	using Castle.Core;
 	using Castle.Core.Configuration;
 	using Castle.Core.Resource;
@@ -33,6 +35,65 @@ namespace Castle.MicroKernel.Tests.Configuration
 	[TestFixture]
 	public class ConfigurationTestCase : AbstractContainerTestCase
 	{
+		
+		
+		
+		
+		[Test]
+		[Bug("https://github.com/castleproject/Windsor/issues/574")]
+		public void DictionaryWithReferencedList()
+		{
+			var config =
+				@"
+<configuration>
+    <facilities>
+    </facilities>
+	<components>
+				<component id='list' type='System.Collections.Generic.List`1[[System.String]]'>
+					<parameters>
+						<collection>
+							<array>
+								<item>11</item>
+								<item>12</item>
+							</array>
+						</collection>
+					</parameters>
+				</component>
+
+				<component id='list2' type='System.Collections.Generic.List`1[[System.String]]'>
+					<parameters>
+						<collection>
+							<array>
+								<item>21</item>
+								<item>22</item>
+							</array>
+						</collection>
+					</parameters>
+				</component>
+
+				<component id='stringToListDictionary' type='System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.List`1[[System.String]]]'>
+					<parameters>
+						<dictionary>
+							<dictionary>
+								<entry key='Key 1'>${list}</entry>
+								<entry key='Key 2'>${list2}</entry>
+							</dictionary>
+						</dictionary>
+					</parameters>
+				</component>
+	</components>
+</configuration>";
+
+			Container.Install(Configuration.FromXml(new StaticContentResource(config)));
+			var stringsList = Container.Resolve<List<string>>("list");
+			var stringToListDictionary = Container.Resolve<Dictionary<string, List<string>>>("stringToListDictionary");
+			Assert.NotNull(stringToListDictionary);
+			Assert.AreEqual(2, stringToListDictionary.Count);
+		}
+		
+		
+		
+		
 		[Test]
 		[Bug("IOC-155")]
 		public void Type_not_implementing_service_should_throw()

--- a/src/Castle.Windsor/MicroKernel/SubSystems/Conversion/GenericListConverter.cs
+++ b/src/Castle.Windsor/MicroKernel/SubSystems/Conversion/GenericListConverter.cs
@@ -42,6 +42,11 @@ namespace Castle.MicroKernel.SubSystems.Conversion
 
 		public override object PerformConversion(String value, Type targetType)
 		{
+			if (value != null && value.Contains("${"))
+			{
+				String newValue = value.Replace("${", "").Replace("}", "");
+				return Context.Kernel.Resolve(newValue, targetType);
+			}
 			throw new NotImplementedException();
 		}
 


### PR DESCRIPTION
https://github.com/castleproject/Windsor/issues/574
Fix dictionary bug where reference to list components didn't work 
