### PR TITLE
Double generic service where one generic parameter is generic itself and has type constraints

### DIFF
--- a/src/Castle.Windsor.Tests/NestedGenericsTestCase.cs
+++ b/src/Castle.Windsor.Tests/NestedGenericsTestCase.cs
@@ -24,7 +24,7 @@ namespace CastleTests
 	{
 
 		[Test]
-		public void ExtendedProperties_incl_ProxyOptions_are_honored_for_open_generic_types()
+		public void Implementation_with_single_generic_parameter_that_is_used_in_double_generic()
 		{
 			Container.Register(
 				Component.For(typeof(IDoubleGeneric<,>))

--- a/src/Castle.Windsor.Tests/NestedGenericsTestCase.cs
+++ b/src/Castle.Windsor.Tests/NestedGenericsTestCase.cs
@@ -1,0 +1,43 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests
+{
+	using Castle.MicroKernel.Registration;
+	using Castle.MicroKernel.Tests.ClassComponents;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class NestedGenericsTestCase : AbstractContainerTestCase
+	{
+
+		[Test]
+		public void ExtendedProperties_incl_ProxyOptions_are_honored_for_open_generic_types()
+		{
+			Container.Register(
+				Component.For(typeof(IDoubleGeneric<,>))
+					.ImplementedBy(typeof(Foo<>)));
+
+			var instance = Container.Resolve<IDoubleGeneric<object, IGenericTypeWithConstraint<object>>>();
+			IDoubleGeneric<object, IGenericTypeWithConstraint<object>> manualInstance = new Foo<object>();
+
+			Assert.IsInstanceOf<IDoubleGeneric<object, IGenericTypeWithConstraint<object>>>(instance);
+		}
+	}
+
+	public class Foo<T> : IDoubleGeneric<T, IGenericTypeWithConstraint<T>> where T : class {}
+
+	public interface IGenericTypeWithConstraint<T> where T : class{}
+}


### PR DESCRIPTION
Today I stumbled over this issue in a day job project. I`m not sure whether I miss something obvious.
The resolve seems to misinterpret the origin of the generic type constraint. I would be happy to help solve this issue, but I would need a bit of finger pointing.

```csharp
	public interface IDoubleGeneric<TOne,TTwo> {   }

	public class Foo<T> : IDoubleGeneric<T, IGenericTypeWithConstraint<T>> where T : class {   }

	public interface IGenericTypeWithConstraint<T> where T : class {   }

        [Test]
        public void Implementation_with_single_generic_parameter_that_is_used_in_double_generic()
        {
	        Container.Register(
		        Component.For(typeof(IDoubleGeneric<,>))
			        .ImplementedBy(typeof(Foo<>)));
        
	        var instance = Container.Resolve<IDoubleGeneric<object, IGenericTypeWithConstraint<object>>>();
	        IDoubleGeneric<object, IGenericTypeWithConstraint<object>> manualInstance = new Foo<object>();
        
	        Assert.IsInstanceOf<IDoubleGeneric<object, IGenericTypeWithConstraint<object>>>(instance);
        }
```

The test fails with:

```
Castle.MicroKernel.Handlers.GenericHandlerTypeMismatchException : Types System.Object, CastleTests.IGenericTypeWithConstraint`1[[System.Object, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]] don't satisfy generic constraints of implementation type CastleTests.Foo`1 of component 'CastleTests.Foo`1'. This is most likely a bug in your code.
   at Castle.MicroKernel.Handlers.DefaultGenericHandler.GetClosedImplementationType(CreationContext context, Boolean instanceRequired) in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\MicroKernel\Handlers\DefaultGenericHandler.cs:line 364
   at Castle.MicroKernel.Handlers.DefaultGenericHandler.Resolve(CreationContext context, Boolean instanceRequired) in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\MicroKernel\Handlers\DefaultGenericHandler.cs:line 184
   at Castle.MicroKernel.Handlers.AbstractHandler.Resolve(CreationContext context) in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\MicroKernel\Handlers\AbstractHandler.cs:line 181
   at Castle.MicroKernel.DefaultKernel.ResolveComponent(IHandler handler, Type service, Arguments additionalArguments, IReleasePolicy policy, Boolean ignoreParentContext) in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\MicroKernel\DefaultKernel.cs:line 751
   at Castle.MicroKernel.DefaultKernel.Castle.MicroKernel.IKernelInternal.Resolve(Type service, Arguments arguments, IReleasePolicy policy, Boolean ignoreParentContext) in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\MicroKernel\DefaultKernel_Resolve.cs:line 185
   at Castle.MicroKernel.DefaultKernel.Resolve(Type service, Arguments arguments) in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\MicroKernel\DefaultKernel_Resolve.cs:line 112
   at Castle.Windsor.WindsorContainer.Resolve[T]() in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor\Windsor\WindsorContainer.cs:line 596
   at CastleTests.NestedGenericsTestCase.Implementation_with_single_generic_parameter_that_is_used_in_double_generic() in C:\Users\anton.herzog\Github\Windsor\src\Castle.Windsor.Tests\NestedGenericsTestCase.cs:line 33
```