### PR TITLE
Update AbstractServiceHostBuilder.Generic.cs

### DIFF
--- a/src/Castle.Facilities.WcfIntegration/Service/AbstractServiceHostBuilder.Generic.cs
+++ b/src/Castle.Facilities.WcfIntegration/Service/AbstractServiceHostBuilder.Generic.cs
@@ -79,7 +79,7 @@ namespace Castle.Facilities.WcfIntegration
 			ValidateComponentModel(model);
 			ValidateServiceModel(model, serviceModel);
 
-			var service = model.Services.Single();
+			var service = model.Services.FirstOrDefault();
 			foreach (var endpoint in serviceModel.Endpoints)
 			{
 				var contract = endpoint.Contract;


### PR DESCRIPTION
var service = model.Services.Single vs  var service = model.Services.FirstOrDefault();
The Single method throws exception when the collection has more one item. I have wrote my own ServiceHostBuilder to allow Service with multiple interfaces.
But this instruction don't allow me  to do.

   protected override void ValidateComponentModel(ComponentModel model)
        {
            //base.ValidateComponentModel(model);
        }
        protected override void ValidateServiceModel(ComponentModel model, ESPServiceModel serviceModel)
        {
          //  base.ValidateServiceModel(model, serviceModel);
        }