### PR TITLE
Limit Castle.Core to <5.0 to avoid breaking changes

### DIFF
--- a/src/Castle.Facilities.AspNet.Mvc.Tests/Castle.Facilities.AspNet.Mvc.Tests.csproj
+++ b/src/Castle.Facilities.AspNet.Mvc.Tests/Castle.Facilities.AspNet.Mvc.Tests.csproj
@@ -14,7 +14,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
 		<PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
 		<PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/Castle.Facilities.AspNet.SystemWeb.Tests/Castle.Facilities.AspNet.SystemWeb.Tests.csproj
+++ b/src/Castle.Facilities.AspNet.SystemWeb.Tests/Castle.Facilities.AspNet.SystemWeb.Tests.csproj
@@ -19,7 +19,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
 		<PackageReference Include="NUnit" Version="3.8.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/Castle.Facilities.AspNet.WebApi.Tests/Castle.Facilities.AspNet.WebApi.Tests.csproj
+++ b/src/Castle.Facilities.AspNet.WebApi.Tests/Castle.Facilities.AspNet.WebApi.Tests.csproj
@@ -14,7 +14,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
 		<PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.3" />
 		<PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/Castle.Facilities.WcfIntegration.Demo/Castle.Facilities.WcfIntegration.Demo.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Demo/Castle.Facilities.WcfIntegration.Demo.csproj
@@ -11,11 +11,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
-		<PackageReference Include="Castle.Core-log4net" Version="4.4.1" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\Castle.Facilities.Logging\Castle.Facilities.Logging.csproj" />
 		<ProjectReference Include="..\Castle.Facilities.WcfIntegration\Castle.Facilities.WcfIntegration.csproj" />
 		<ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />

--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
@@ -12,8 +12,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
-		<PackageReference Include="Castle.Core-log4net" Version="4.4.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
 		<PackageReference Include="NUnit" Version="3.8.1" />

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -50,8 +50,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">
-    <PackageReference Include="Castle.Core-log4net" Version="4.4.1" />
-    <PackageReference Include="Castle.Core-NLog" Version="4.4.1" />
+    <PackageReference Include="Castle.Core-log4net" Version="[4.4.1,5.0)" />
+    <PackageReference Include="Castle.Core-NLog" Version="[4.4.1,5.0)" />
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
 	</ItemGroup>
 	

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -50,9 +50,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
-		<PackageReference Include="Castle.Core-log4net" Version="4.4.1" />
-		<PackageReference Include="Castle.Core-NLog" Version="4.4.1" />
+    <PackageReference Include="Castle.Core-log4net" Version="4.4.1" />
+    <PackageReference Include="Castle.Core-NLog" Version="4.4.1" />
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
 	</ItemGroup>
 	

--- a/src/Castle.Windsor/Castle.Windsor.csproj
+++ b/src/Castle.Windsor/Castle.Windsor.csproj
@@ -24,7 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
+		<PackageReference Include="Castle.Core" Version="[4.4.1,5.0)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">


### PR DESCRIPTION
With the release of Castle.Core@5.0.0, there are a number of breaking changes (for example https://github.com/castleproject/Core/pull/563) that affect Windsor.

Example code that blows up:

```var container = new WindsorContainer().Install(FromAssembly.Named("Does.Not.Matter"));```

Gives an exceptions along the lines:

```
System.TypeLoadException : Could not load type 'Castle.Core.Internal.PermissionUtil' from assembly 'Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc'.

System.TypeLoadException : Could not load type 'Castle.Core.Pair`2' from assembly 'Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc'.
```

This PR limits the upper version of Castle.Core to < 5.0, so that these changes don't bite consumers at runtime, until Windsor is updated to support the new version.

Took the opportunity to remove unnecessary references to Castle.Core in Facility projects that transitively include it already by referencing the base Castle.Windsor project.