### PR TITLE
Add `ComVisible(false)` to `CommonAssemblyInfo.cs` to resolve #604

### DIFF
--- a/buildscripts/CommonAssemblyInfo.cs
+++ b/buildscripts/CommonAssemblyInfo.cs
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Runtime.InteropServices;
+
 [assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]


### PR DESCRIPTION
The move to SDK project file format meant the `[assembly: ComVisible(false)]` setting was lost. This PR re-adds it to resolve #604.