### PR TITLE
Create parallel data structure for types to fasten up lookups later.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add fast lookup to check for already registered types. (@sqeezy, #618)
 - Change target framework from .NET Standard 1.6 to 2.0 (@generik0, #572)
 
 Bugfixes:

--- a/src/Castle.Windsor/Core/ComponentModel.cs
+++ b/src/Castle.Windsor/Core/ComponentModel.cs
@@ -40,6 +40,7 @@ namespace Castle.Core
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private readonly List<Type> services = new List<Type>(4);
+		private HashSet<Type> servicesFast = new HashSet<Type>();
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private ComponentName componentName;
@@ -331,6 +332,12 @@ namespace Castle.Core
 		{
 			get { return services; }
 		}
+		
+		[DebuggerDisplay("Count = {services.Count}")]
+		public HashSet<Type> FastServices
+		{
+			get { return servicesFast; }
+		}
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		internal ParameterModelCollection ParametersInternal
@@ -378,7 +385,7 @@ namespace Castle.Core
 					              type));
 			}
 
-			ComponentServicesUtil.AddService(services, type);
+			ComponentServicesUtil.AddService(services,servicesFast, type);
 		}
 
 		/// <summary>

--- a/src/Castle.Windsor/Core/ComponentModel.cs
+++ b/src/Castle.Windsor/Core/ComponentModel.cs
@@ -333,8 +333,7 @@ namespace Castle.Core
 			get { return services; }
 		}
 		
-		[DebuggerDisplay("Count = {services.Count}")]
-		public HashSet<Type> FastServices
+		internal HashSet<Type> FastServices
 		{
 			get { return servicesFast; }
 		}

--- a/src/Castle.Windsor/Core/ComponentModel.cs
+++ b/src/Castle.Windsor/Core/ComponentModel.cs
@@ -333,9 +333,9 @@ namespace Castle.Core
 			get { return services; }
 		}
 		
-		internal HashSet<Type> FastServices
+		internal HashSet<Type> ServicesLookup
 		{
-			get { return servicesFast; }
+			get { return servicesLookup; }
 		}
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Castle.Windsor/Core/ComponentModel.cs
+++ b/src/Castle.Windsor/Core/ComponentModel.cs
@@ -40,7 +40,7 @@ namespace Castle.Core
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private readonly List<Type> services = new List<Type>(4);
-		private HashSet<Type> servicesFast = new HashSet<Type>();
+		private readonly HashSet<Type> servicesLookup = new HashSet<Type>();
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private ComponentName componentName;

--- a/src/Castle.Windsor/Core/ComponentModel.cs
+++ b/src/Castle.Windsor/Core/ComponentModel.cs
@@ -384,7 +384,7 @@ namespace Castle.Core
 					              type));
 			}
 
-			ComponentServicesUtil.AddService(services,servicesFast, type);
+			ComponentServicesUtil.AddService(services, servicesLookup, type);
 		}
 
 		/// <summary>

--- a/src/Castle.Windsor/Core/Internal/ComponentServicesUtil.cs
+++ b/src/Castle.Windsor/Core/Internal/ComponentServicesUtil.cs
@@ -22,7 +22,7 @@ namespace Castle.Core.Internal
 	{
 		private static readonly TypeByInheritanceDepthMostSpecificFirstComparer comparer = new TypeByInheritanceDepthMostSpecificFirstComparer();
 
-		public static void AddService(IList<Type> existingServices,HashSet<Type> lookup, Type newService)
+		public static void AddService(IList<Type> existingServices, HashSet<Type> lookup, Type newService)
 		{
 			if (lookup.Contains(newService))
 			{

--- a/src/Castle.Windsor/Core/Internal/ComponentServicesUtil.cs
+++ b/src/Castle.Windsor/Core/Internal/ComponentServicesUtil.cs
@@ -22,15 +22,16 @@ namespace Castle.Core.Internal
 	{
 		private static readonly TypeByInheritanceDepthMostSpecificFirstComparer comparer = new TypeByInheritanceDepthMostSpecificFirstComparer();
 
-		public static void AddService(IList<Type> existingServices, Type newService)
+		public static void AddService(IList<Type> existingServices,HashSet<Type> lookup, Type newService)
 		{
-			if (existingServices.Contains(newService))
+			if (lookup.Contains(newService))
 			{
 				return;
 			}
 			if (newService.GetTypeInfo().IsInterface)
 			{
 				existingServices.Add(newService);
+				lookup.Add(newService);
 				return;
 			}
 			if (newService.GetTypeInfo().IsClass == false)
@@ -44,11 +45,13 @@ namespace Castle.Core.Internal
 				if (existingServices[i].GetTypeInfo().IsInterface)
 				{
 					existingServices.Insert(i, newService);
+					lookup.Add(newService);
 				}
 				var result = comparer.Compare(newService, existingServices[i]);
 				if (result < 0)
 				{
 					existingServices.Insert(i, newService);
+					lookup.Add(newService);
 					return;
 				}
 				if (result == 0)
@@ -56,6 +59,7 @@ namespace Castle.Core.Internal
 					return;
 				}
 			}
+			lookup.Add(newService);
 			existingServices.Add(newService);
 		}
 	}

--- a/src/Castle.Windsor/MicroKernel/Handlers/AbstractHandler.cs
+++ b/src/Castle.Windsor/MicroKernel/Handlers/AbstractHandler.cs
@@ -183,7 +183,7 @@ namespace Castle.MicroKernel.Handlers
 
 		public virtual bool Supports(Type service)
 		{
-			return ComponentModel.FastServices.Contains(service);
+			return ComponentModel.ServicesLookup.Contains(service);
 		}
 
 		public virtual bool SupportsAssignable(Type service)

--- a/src/Castle.Windsor/MicroKernel/Handlers/AbstractHandler.cs
+++ b/src/Castle.Windsor/MicroKernel/Handlers/AbstractHandler.cs
@@ -183,7 +183,7 @@ namespace Castle.MicroKernel.Handlers
 
 		public virtual bool Supports(Type service)
 		{
-			return ComponentModel.Services.Contains(service);
+			return ComponentModel.FastServices.Contains(service);
 		}
 
 		public virtual bool SupportsAssignable(Type service)

--- a/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
@@ -47,7 +47,7 @@ namespace Castle.MicroKernel.Registration
 	{
 		private readonly List<IComponentModelDescriptor> descriptors = new List<IComponentModelDescriptor>();
 		private readonly List<Type> potentialServices = new List<Type>();
-		private readonly HashSet<Type> potentialServicesFast = new HashSet<Type>();
+		private readonly HashSet<Type> potentialServicesLookup = new HashSet<Type>();
 
 		private bool ifComponentRegisteredIgnore;
 		private Type implementation;

--- a/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
@@ -474,7 +474,7 @@ namespace Castle.MicroKernel.Registration
 		{
 			foreach (var type in types)
 			{
-				ComponentServicesUtil.AddService(potentialServices,potentialServicesFast , type);
+				ComponentServicesUtil.AddService(potentialServices, potentialServicesLookup, type);
 			}
 			return this;
 		}

--- a/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
@@ -47,6 +47,7 @@ namespace Castle.MicroKernel.Registration
 	{
 		private readonly List<IComponentModelDescriptor> descriptors = new List<IComponentModelDescriptor>();
 		private readonly List<Type> potentialServices = new List<Type>();
+		private readonly HashSet<Type> potentialServicesFast = new HashSet<Type>();
 
 		private bool ifComponentRegisteredIgnore;
 		private Type implementation;
@@ -473,7 +474,7 @@ namespace Castle.MicroKernel.Registration
 		{
 			foreach (var type in types)
 			{
-				ComponentServicesUtil.AddService(potentialServices, type);
+				ComponentServicesUtil.AddService(potentialServices,potentialServicesFast , type);
 			}
 			return this;
 		}


### PR DESCRIPTION
When profiling application build times I noticed that a lot of my performance went into a List.Contains call.
This seems like a problem that's easily solved. I'm well aware that I might have missed some detail here, but this kind of change would bring a lot of performance to applications registering a lot of components.

This is just a rough draft, but I would be very much interested in your input and explanations.

Thank you! 