### PR TITLE
NUNIT_SETCULTUREATTRIBUTE and NUNIT_TIMEOUTATTRIBUTE (Remove)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,3 @@ The following conditional compilation symbols are defined for tests only under .
 * `FEATURE_CONSOLETRACELISTENER` - enables code that requires `System.Diagnostics.ConsoleTraceListener`.
 * `FEATURE_THREADABORT` - enables code that uses `Thread.Abort()`.
 * `FEATURE_WPF` - enables code that uses `PresentationCore.dll`.
-* `NUNIT_SETCULTUREATTRIBUTE` - uses `NUnit.Framework.SetCultureAttribute`.
-* `NUNIT_TIMEOUTATTRIBUTE` - uses `NUnit.Framework.TimeoutAttribute`.

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -70,7 +70,7 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net462'">
-		<DefineConstants>$(DefineConstants);NUNIT_SETCULTUREATTRIBUTE;NUNIT_TIMEOUTATTRIBUTE;FEATURE_THREADABORT;FEATURE_WPF;FEATURE_CONSOLETRACELISTENER</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_THREADABORT;FEATURE_WPF;FEATURE_CONSOLETRACELISTENER</DefineConstants>
 	</PropertyGroup>
 
 </Project>

--- a/src/Castle.Windsor.Tests/DefaultConversionManagerTestCase.cs
+++ b/src/Castle.Windsor.Tests/DefaultConversionManagerTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,20 +29,17 @@ namespace CastleTests
 	{
 		private readonly DefaultConversionManager converter = new DefaultConversionManager();
 
-#if NUNIT_SETCULTUREATTRIBUTE
-		// currently not supported by SL
 		[Test]
 		[SetCulture("pl-PL")]
 		[Bug("IOC-314")]
-		public void Converting_numbers_uses_oridinal_culture()
+		public void Converting_numbers_uses_ordinal_culture()
 		{
 			Assert.AreEqual(",", Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator);
 
-			var result = converter.PerformConversion<Decimal>("123.456");
+			var result = converter.PerformConversion<decimal>("123.456");
 
 			Assert.AreEqual(123.456m, result);
 		}
-#endif
 
 		[Test]
 		public void PerformConversionInt()

--- a/src/Castle.Windsor.Tests/LazyLoadingTestCase.cs
+++ b/src/Castle.Windsor.Tests/LazyLoadingTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,7 +63,6 @@ namespace Castle.MicroKernel.Tests
 			Container.Resolve<B>();
 		}
 
-#if NUNIT_TIMEOUTATTRIBUTE
 		[Test]
 		[Timeout(2000)]
 		public void Loaders_are_thread_safe()
@@ -98,7 +97,6 @@ namespace Castle.MicroKernel.Tests
 			Assert.IsNull(exception);
 			Assert.AreEqual(0, count[0]);
 		}
-#endif
 
 		[Test]
 		public void Loaders_only_triggered_when_resolving()


### PR DESCRIPTION
As the code now targets `netstandard2.0` rather than `netstandard1.6`, this conditional compilation symbol can be removed.

Draft: Requires update to NUnit covered by #630