### PR TITLE
Refs: #646 Castle.Windsor.Extension.DepencencyInjection removed null check on scope cache

### DIFF
--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,0 +1,56 @@
+﻿using Castle.MicroKernel.Registration;
+using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests {
+	public class ResolveFromThreadpoolUnsafe {
+		[Fact]
+		public async Task Can_Resolve_From_ServiceProvider() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				Component.For<IUserService>().ImplementedBy<UserService>()
+			);
+
+			IServiceProvider sp = f.CreateServiceProvider(container);
+
+			var actualUserService = sp.GetService<IUserService>();
+			Assert.NotNull(actualUserService);
+
+			/*
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				// resolving using castle (without scopes) works
+				var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+				Assert.NotNull(actualUserService);
+			}, null);
+			*/
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				try {
+					var actualUserService = sp.GetService<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,4 +1,5 @@
 ﻿using Castle.MicroKernel.Registration;
+using Castle.Windsor.Extensions.DependencyInjection.Extensions;
 using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -38,6 +39,84 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests {
 			ThreadPool.UnsafeQueueUserWorkItem(state => {
 				try {
 					var actualUserService = sp.GetService<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public async Task Can_Resolve_From_CastleWindsor() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				// Component.For<IUserService>().ImplementedBy<UserService>().LifestyleNetTransient(),
+				Classes.FromThisAssembly().BasedOn<IUserService>().WithServiceAllInterfaces().LifestyleNetStatic()
+				);
+
+			IUserService actualUserService;
+			actualUserService = container.Resolve<IUserService>();
+			Assert.NotNull(actualUserService);
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				IUserService actualUserService = null;
+				try {
+					// resolving (with the underlying Castle Windsor, not using Service Provider) with a lifecycle that has an
+					// accessor that uses something that is AsyncLocal might be troublesome.
+					// the custom lifecycle accessor will kicks in, but noone assigns the Current scope (which is uninitialized)
+					actualUserService = container.Resolve<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public async Task Can_Resolve_From_ServiceProvider_cretaed_in_UnsafeQueueUserWorkItem() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				// Component.For<IUserService>().ImplementedBy<UserService>().LifestyleNetTransient(),
+				Classes.FromThisAssembly().BasedOn<IUserService>().WithServiceAllInterfaces().LifestyleNetStatic()
+				);
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				IUserService actualUserService = null;
+				try {
+					// creating a service provider here will be troublesome too
+					IServiceProvider sp = f.CreateServiceProvider(container);
+
+					actualUserService = sp.GetService<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex) {

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Windsor.Extensions.DependencyInjection.Scope
-{
+namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 	using System;
 
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
 
-	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor
-	{
-		public ILifetimeScope GetScope(CreationContext context)
-		{
+	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor {
+		public ILifetimeScope GetScope(CreationContext context) {
+			if (ExtensionContainerScopeCache.Current == null) {
+				// might be null in threads spawn from Threadpool.UnsafeQueueUserWorkItem
+				return null;
+			}
 			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
 		}
 
-		public void Dispose()
-		{
+		public void Dispose() {
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value ?? throw new InvalidOperationException("No scope available");
+			get => current.Value; // ?? throw new InvalidOperationException("No scope available");
 			set => current.Value = value;
 		}
 	}


### PR DESCRIPTION
ExtensionContainerScopeCache.current is an `AsyncLocal<ExtensionContainerScopeBase>`, AsyncLocal might not be captured in threads originating from `Threadpool.UnsafeQueueUserWorkItem`.

AspNetCore make heavy use of such threads to optimize performances.

Quick fir was just to removed the null check.

I also added a test that replicates the scenario.

However having "null" for the current scope might be questionable, the Dispose in WindsorScopedServiceProvider rely on that information to correctly cleanup the things.
The behavior might still be good because disposing a ServiceProvider resolved/used in a background thread should not dispose the main container anyway.