### PR TITLE
Refs: #646 Castle.Windsor.Extension.DepencencyInjection - No Scope Available

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ indent_size = 2
 [*.cs]
 indent_style = tab
 indent_size = 4
+csharp_new_line_before_open_brace = all

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -13,6 +13,11 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 	{
 		#region Singleton
 
+		/* 
+		 * Singleton tests should never fail, given you have a container instance you should always
+		 * be able to resolve a singleton from it. 
+		 */
+
 		[Fact]
 		public async Task Can_Resolve_LifestyleSingleton_From_ServiceProvider()
 		{
@@ -51,6 +56,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -76,7 +84,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -91,6 +99,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -131,6 +142,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -156,7 +170,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -171,11 +185,19 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		#endregion
 
 		#region Scoped
+
+		/*
+		 * Scoped tests might fail if for whatever reason you do not have a current scope
+		 * (like when you run from Threadpool.UnsafeQueueUserWorkItem).
+		 */
 
 		[Fact]
 		public async Task Can_Resolve_LifestyleScoped_From_ServiceProvider()
@@ -215,6 +237,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -240,7 +265,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -255,8 +280,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
+		/// <summary>
+		/// This test succeeds because WindsorScopedServiceProvider captured the root scope on creation
+		/// and forced it to be current before service resolution.
+		/// Scoped is tied to the rootscope = potential memory leak.
+		/// </summary>
 		[Fact]
 		public async Task Can_Resolve_LifestyleScopedToNetServiceScope_From_ServiceProvider()
 		{
@@ -295,6 +328,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -320,7 +356,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -335,11 +371,25 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		#endregion
 
 		#region Transient
+
+		/*
+		 * Transient tests failure is questionable:
+		 * - if you have a container you should be able to resolve transient without a scope,
+		 *   but they might be tracked by the container itself (or the IServiceProvider)
+		 * - when windsor container is disposed all transient services are disposed as well
+		 * - when a IServiceProvider is disposed all transient services (created by it) are disposed as well
+		 * - problem is: we have una instance of a windsor container passed on to multiple instances of IServiceProvider
+		 *   one solution will be to tie the Transients to a scope, and the scope is tied to service provider
+		 *   when both of them are disposed, the transient services are disposed as well
+		 */
 
 		[Fact]
 		public async Task Can_Resolve_LifestyleTransient_From_ServiceProvider()
@@ -379,6 +429,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -404,7 +457,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -419,8 +472,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
+		/// <summary>
+		/// This test succeeds because WindsorScopedServiceProvider captured the root scope on creation
+		/// and forced it to be current before service resolution.
+		/// Transient is tied to the rootscope = potential memory leak.
+		/// </summary>
 		[Fact]
 		public async Task Can_Resolve_LifestyleNetTransient_From_ServiceProvider()
 		{
@@ -459,6 +520,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -484,7 +548,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -499,8 +563,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		#endregion
+
+		/*
+		 * Missing tests: we should also test what happens with injected IServiceProvider (what scope do they get?)
+		 * Injected IServiceProvider might or might not have a scope (it depends on AsyncLocal value).
+		 */
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -9,8 +9,41 @@ using Xunit;
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 {
-	public class ResolveFromThreadpoolUnsafe
+	[CollectionDefinition(nameof(DoNotParallelize), DisableParallelization = true)]
+	public class DoNotParallelize { }
+
+	/// <summary>
+	/// These is the original Castle Windsor Dependency Injection behavior.
+	/// </summary>
+	public class ResolveFromThreadpoolUnsafe_NetStatic: AbstractResolveFromThreadpoolUnsafe
 	{
+		public ResolveFromThreadpoolUnsafe_NetStatic() : base(false)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Mapping NetStatic to usual Singleton lifestyle.
+	/// </summary>
+	public class ResolveFromThreadpoolUnsafe_Singleton : AbstractResolveFromThreadpoolUnsafe
+	{
+		public ResolveFromThreadpoolUnsafe_Singleton() : base(true)
+		{
+		}
+	}
+
+	/// <summary>
+	/// relying on static state (WindsorDependencyInjectionOptions) is not good for tests
+	/// that might run in parallel, can lead to false positives / negatives.
+	/// </summary>
+	[Collection(nameof(DoNotParallelize))]
+	public abstract class AbstractResolveFromThreadpoolUnsafe
+	{
+		protected AbstractResolveFromThreadpoolUnsafe(bool mapNetStaticToSingleton)
+		{
+			WindsorDependencyInjectionOptions.MapNetStaticToSingleton = mapNetStaticToSingleton;
+		}
+
 		#region Singleton
 
 		/* 
@@ -147,6 +180,10 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			container.Dispose();
 		}
 
+		/// <summary>
+		/// This test will Succeed is we use standard Castle Windsor Singleton lifestyle instead of the custom
+		/// NetStatic lifestyle.
+		/// </summary>
 		[Fact]
 		public async Task Can_Resolve_LifestyleNetStatic_From_WindsorContainer()
 		{

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,0 +1,56 @@
+﻿using Castle.MicroKernel.Registration;
+using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests {
+	public class ResolveFromThreadpoolUnsafe {
+		[Fact]
+		public async Task Can_Resolve_From_ServiceProvider() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				Component.For<IUserService>().ImplementedBy<UserService>()
+			);
+
+			IServiceProvider sp = f.CreateServiceProvider(container);
+
+			var actualUserService = sp.GetService<IUserService>();
+			Assert.NotNull(actualUserService);
+
+			/*
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				// resolving using castle (without scopes) works
+				var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+				Assert.NotNull(actualUserService);
+			}, null);
+			*/
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				try {
+					var actualUserService = sp.GetService<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,4 +1,5 @@
 ﻿using Castle.MicroKernel.Registration;
+using Castle.Windsor.Extensions.DependencyInjection.Extensions;
 using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -38,6 +39,84 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests {
 			ThreadPool.UnsafeQueueUserWorkItem(state => {
 				try {
 					var actualUserService = sp.GetService<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public async Task Can_Resolve_From_CastleWindsor() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				// Component.For<IUserService>().ImplementedBy<UserService>().LifestyleNetTransient(),
+				Classes.FromThisAssembly().BasedOn<IUserService>().WithServiceAllInterfaces().LifestyleNetStatic()
+				);
+
+			IUserService actualUserService;
+			actualUserService = container.Resolve<IUserService>();
+			Assert.NotNull(actualUserService);
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				IUserService actualUserService = null;
+				try {
+					// resolving (with the underlying Castle Windsor, not using Service Provider) with a lifecycle that has an
+					// accessor that uses something that is AsyncLocal might be troublesome.
+					// the custom lifecycle accessor will kicks in, but noone assigns the Current scope (which is uninitialized)
+					actualUserService = container.Resolve<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public async Task Can_Resolve_From_ServiceProvider_cretaed_in_UnsafeQueueUserWorkItem() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				// Component.For<IUserService>().ImplementedBy<UserService>().LifestyleNetTransient(),
+				Classes.FromThisAssembly().BasedOn<IUserService>().WithServiceAllInterfaces().LifestyleNetStatic()
+				);
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				IUserService actualUserService = null;
+				try {
+					// creating a service provider here will be troublesome too
+					IServiceProvider sp = f.CreateServiceProvider(container);
+
+					actualUserService = sp.GetService<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex) {

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
@@ -49,10 +49,13 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 		/// <typeparam name="TService"></typeparam>
 		public static ComponentRegistration<TService> NetStatic<TService>(this LifestyleGroup<TService> lifestyle) where TService : class
 		{
-			//return lifestyle.Singleton;
-			// I don't think we need this lifestyle at all, usual Singleton should be good
-			// also we don't need the whole rootscope thing a normal scope set as current should be enough
+			// I don't think we need this lifestyle at all, usual Singleton should be good enough;
+			// also we maybe don't need the whole rootscope thing. A normal scope set as current should be enough
 			// otherwise we should revert to static rootscope
+			if (WindsorDependencyInjectionOptions.MapNetStaticToSingleton)
+			{
+				return lifestyle.Singleton;
+			}
 			return lifestyle
 				.Scoped<ExtensionContainerRootScopeAccessor>();
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
@@ -49,6 +49,10 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 		/// <typeparam name="TService"></typeparam>
 		public static ComponentRegistration<TService> NetStatic<TService>(this LifestyleGroup<TService> lifestyle) where TService : class
 		{
+			//return lifestyle.Singleton;
+			// I don't think we need this lifestyle at all, usual Singleton should be good
+			// also we don't need the whole rootscope thing a normal scope set as current should be enough
+			// otherwise we should revert to static rootscope
 			return lifestyle
 				.Scoped<ExtensionContainerRootScopeAccessor>();
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -12,101 +12,123 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Windsor.Extensions.DependencyInjection {
-    using System;
+namespace Castle.Windsor.Extensions.DependencyInjection
+{
+	using System;
 
-    using Castle.MicroKernel.Registration;
-    using Castle.Windsor.Extensions.DependencyInjection.Extensions;
+	using Castle.MicroKernel.Registration;
+	using Castle.Windsor.Extensions.DependencyInjection.Extensions;
 
-    using Microsoft.Extensions.DependencyInjection;
+	using Microsoft.Extensions.DependencyInjection;
 
-    internal static class RegistrationAdapter {
-        public static IRegistration FromOpenGenericServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) {
-            ComponentRegistration<object> registration = Component.For(service.ServiceType)
-                .NamedAutomatically(UniqueComponentName(service));
+	internal static class RegistrationAdapter
+	{
+		public static IRegistration FromOpenGenericServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		{
+			ComponentRegistration<object> registration = Component.For(service.ServiceType)
+				.NamedAutomatically(UniqueComponentName(service));
 
-            if (service.ImplementationType != null) {
-                registration = UsingImplementation(registration, service);
-            }
-            else {
-                throw new System.ArgumentException("Unsupported ServiceDescriptor");
-            }
+			if (service.ImplementationType != null)
+			{
+				registration = UsingImplementation(registration, service);
+			}
+			else
+			{
+				throw new System.ArgumentException("Unsupported ServiceDescriptor");
+			}
 
-            return ResolveLifestyle(registration, service)
-                .IsDefault();
-        }
+			return ResolveLifestyle(registration, service)
+				.IsDefault();
+		}
 
-        public static IRegistration FromServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) {
-            var registration = Component.For(service.ServiceType)
-                .NamedAutomatically(UniqueComponentName(service));
+		public static IRegistration FromServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		{
+			var registration = Component.For(service.ServiceType)
+				.NamedAutomatically(UniqueComponentName(service));
 
-            if (service.ImplementationFactory != null) {
-                registration = UsingFactoryMethod(registration, service);
-            }
-            else if (service.ImplementationInstance != null) {
-                registration = UsingInstance(registration, service);
-            }
-            else if (service.ImplementationType != null) {
-                registration = UsingImplementation(registration, service);
-            }
+			if (service.ImplementationFactory != null)
+			{
+				registration = UsingFactoryMethod(registration, service);
+			}
+			else if (service.ImplementationInstance != null)
+			{
+				registration = UsingInstance(registration, service);
+			}
+			else if (service.ImplementationType != null)
+			{
+				registration = UsingImplementation(registration, service);
+			}
 
-            return ResolveLifestyle(registration, service)
-                .IsDefault();
-        }
+			return ResolveLifestyle(registration, service)
+				.IsDefault();
+		}
 
-        public static string OriginalComponentName(string uniqueComponentName) {
-            if (uniqueComponentName == null) {
-                return null;
-            }
-            if (!uniqueComponentName.Contains("@")) {
-                return uniqueComponentName;
-            }
-            return uniqueComponentName.Split('@')[0];
-        }
+		public static string OriginalComponentName(string uniqueComponentName)
+		{
+			if (uniqueComponentName == null)
+			{
+				return null;
+			}
+			if (!uniqueComponentName.Contains("@"))
+			{
+				return uniqueComponentName;
+			}
+			return uniqueComponentName.Split('@')[0];
+		}
 
-        internal static string UniqueComponentName(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) {
-            var result = "";
-            if (service.ImplementationType != null) {
-                result = service.ImplementationType.FullName;
-            }
-            else if (service.ImplementationInstance != null) {
-                result = service.ImplementationInstance.GetType().FullName;
-            }
-            else {
-                result = service.ImplementationFactory.GetType().FullName;
-            }
-            result = result + "@" + Guid.NewGuid().ToString();
+		internal static string UniqueComponentName(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		{
+			var result = "";
+			if (service.ImplementationType != null)
+			{
+				result = service.ImplementationType.FullName;
+			}
+			else if (service.ImplementationInstance != null)
+			{
+				result = service.ImplementationInstance.GetType().FullName;
+			}
+			else
+			{
+				result = service.ImplementationFactory.GetType().FullName;
+			}
+			result = result + "@" + Guid.NewGuid().ToString();
 
-            return result;
-        }
+			return result;
+		}
 
-        private static ComponentRegistration<TService> UsingFactoryMethod<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            return registration.UsingFactoryMethod((kernel) => {
-                var serviceProvider = kernel.Resolve<System.IServiceProvider>();
-                return service.ImplementationFactory(serviceProvider) as TService;
-            });
-        }
+		private static ComponentRegistration<TService> UsingFactoryMethod<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			return registration.UsingFactoryMethod((kernel) =>
+			{
+				var serviceProvider = kernel.Resolve<System.IServiceProvider>();
+				return service.ImplementationFactory(serviceProvider) as TService;
+			});
+		}
 
-        private static ComponentRegistration<TService> UsingInstance<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            return registration.Instance(service.ImplementationInstance as TService);
-        }
+		private static ComponentRegistration<TService> UsingInstance<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			return registration.Instance(service.ImplementationInstance as TService);
+		}
 
-        private static ComponentRegistration<TService> UsingImplementation<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            return registration.ImplementedBy(service.ImplementationType);
-        }
+		private static ComponentRegistration<TService> UsingImplementation<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			return registration.ImplementedBy(service.ImplementationType);
+		}
 
-        private static ComponentRegistration<TService> ResolveLifestyle<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            switch (service.Lifetime) {
-                case ServiceLifetime.Singleton:
-                    return registration.LifeStyle.NetStatic();
-                case ServiceLifetime.Scoped:
-                    return registration.LifeStyle.ScopedToNetServiceScope();
-                case ServiceLifetime.Transient:
-                    return registration.LifestyleNetTransient();
+		private static ComponentRegistration<TService> ResolveLifestyle<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			switch (service.Lifetime)
+			{
+				case ServiceLifetime.Singleton:
+					return registration.LifeStyle.NetStatic();
+				case ServiceLifetime.Scoped:
+					return registration.LifeStyle.ScopedToNetServiceScope();
+				case ServiceLifetime.Transient:
+					return registration.LifestyleNetTransient();
 
-                default:
-                    throw new System.ArgumentException($"Invalid lifetime {service.Lifetime}");
-            }
-        }
-    }
+				default:
+					throw new System.ArgumentException($"Invalid lifetime {service.Lifetime}");
+			}
+		}
+	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -26,7 +26,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 				return null;
 			}
 			*/
-			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
+			return ExtensionContainerScopeCache.Current?.RootScope ?? throw new InvalidOperationException("No root scope available.");
 		}
 
 		public void Dispose() {

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -20,10 +20,12 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 
 	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor {
 		public ILifetimeScope GetScope(CreationContext context) {
+			/*
 			if (ExtensionContainerScopeCache.Current == null) {
 				// might be null in threads spawn from Threadpool.UnsafeQueueUserWorkItem
 				return null;
 			}
+			*/
 			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
 		}
 

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Windsor.Extensions.DependencyInjection.Scope
-{
+namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 	using System;
 
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
 
-	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor
-	{
-		public ILifetimeScope GetScope(CreationContext context)
-		{
+	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor {
+		public ILifetimeScope GetScope(CreationContext context) {
+			if (ExtensionContainerScopeCache.Current == null) {
+				// might be null in threads spawn from Threadpool.UnsafeQueueUserWorkItem
+				return null;
+			}
 			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
 		}
 
-		public void Dispose()
-		{
+		public void Dispose() {
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
@@ -25,10 +25,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 
 		internal override ExtensionContainerScopeBase RootScope { get; set; }
 
-
 		internal static ExtensionContainerScopeBase BeginScope()
 		{
-			var scope = new ExtensionContainerScope { RootScope = ExtensionContainerScopeCache.Current.RootScope };
+			var scope = new ExtensionContainerScope { RootScope = ExtensionContainerScopeCache.Current?.RootScope };
 			ExtensionContainerScopeCache.Current = scope;
 			return scope;
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeAccessor.cs
@@ -16,12 +16,13 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
+	using System;
 
 	internal class ExtensionContainerScopeAccessor : IScopeAccessor
 	{
 		public ILifetimeScope GetScope(CreationContext context)
 		{
-			return ExtensionContainerScopeCache.Current;
+			return ExtensionContainerScopeCache.Current ?? throw new InvalidOperationException("No scope available. Did you forget to call IServiceScopeFactory.CreateScope()?"); ;
 		}
 
 		public void Dispose()

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value ?? throw new InvalidOperationException("No scope available");
+			get => current.Value; // ?? throw new InvalidOperationException("No scope available");
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value ?? throw new InvalidOperationException("No scope available"); // originally there was no exception
+			// AysncLocal can be null in some cases (like Threadpool.UnsafeQueueUserWorkItem)
+			get => current.Value; // ?? throw new InvalidOperationException("No scope available. Did you forget to call IServiceScopeFactory.CreateScope()?");
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value; // ?? throw new InvalidOperationException("No scope available");
+			get => current.Value ?? throw new InvalidOperationException("No scope available"); // originally there was no exception
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorDependencyInjectionOptions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorDependencyInjectionOptions.cs
@@ -1,0 +1,16 @@
+﻿namespace Castle.Windsor.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// Global settins to change the dependency injection behavior.
+	/// These settings should be set before the container is created.
+	/// </summary>
+	public static class WindsorDependencyInjectionOptions
+	{
+		/// <summary>
+		/// Map NetStatic lifestyle to Castle Windsor Singleton lifestyle.
+		/// The whole RootScope handling is disabled.
+		/// (defaut: false)
+		/// </summary>
+		public static bool MapNetStaticToSingleton { get; set; }
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
@@ -18,7 +18,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 	using System;
 	using System.Collections.Generic;
 	using System.Reflection;
-	
+
 	using Castle.Windsor;
 	using Castle.Windsor.Extensions.DependencyInjection.Scope;
 
@@ -30,7 +30,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 		private bool disposing;
 
 		private readonly IWindsorContainer container;
-		
+
 		public WindsorScopedServiceProvider(IWindsorContainer container)
 		{
 			this.container = container;
@@ -39,27 +39,30 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 		public object GetService(Type serviceType)
 		{
-			using(_ = new ForcedScope(scope))
+			using (_ = new ForcedScope(scope))
 			{
-				return ResolveInstanceOrNull(serviceType, true);	
+				return ResolveInstanceOrNull(serviceType, true);
 			}
 		}
 
 		public object GetRequiredService(Type serviceType)
 		{
-			using(_ = new ForcedScope(scope))
+			using (_ = new ForcedScope(scope))
 			{
-				return ResolveInstanceOrNull(serviceType, false);	
+				return ResolveInstanceOrNull(serviceType, false);
 			}
 		}
 
 		public void Dispose()
 		{
+			// root scope should be tied to the root IserviceProvider, so
+			// it has to be disposed with the IserviceProvider to which is tied to
 			if (!(scope is ExtensionContainerRootScope)) return;
 			if (disposing) return;
 			disposing = true;
 			var disposableScope = scope as IDisposable;
 			disposableScope?.Dispose();
+			// disping the container here is questionable... what if I want to create another IServiceProvider form the factory?
 			container.Dispose();
 		}
 		private object ResolveInstanceOrNull(Type serviceType, bool isOptional)


### PR DESCRIPTION
ExtensionContainerScopeCache.current is an AsyncLocal<ExtensionContainerScopeBase>, AsyncLocal might not be captured in threads originating from Threadpool.UnsafeQueueUserWorkItem.

AspNetCore make heavy use of such threads to optimize performances.

I Added some tests that show supported and unsupported scenarios

I moved the null checks from the AsyncLocal Cache to the scope accessors and improved error messages a bit.

Added an experimental feature to use Castle Windsor standard Singleton lifecycle instead of the custom NetStatic (I believe singletons should always be resolved if you have a container instance whatever the scope is). Enabling it helps me solve singleton resolution issues when the same components are resolved from the IServiceProvider and/or WindsorContainer.

However having "null" for the current scope might be questionable, the Dispose in WindsorScopedServiceProvider rely on that information to correctly cleanup the things (looking at the dotnet DI code, the root scope should be strictly tied to the root service provider).
This behavior might still be good because disposing a ServiceProvider resolved/used in a background thread should not dispose the main container anyway.

I think that more changes should be done like:
- do not dispose the container in WindsorScopedServiceProvider, but dispose it in the factory (only if it creates the container instance)
- create the root scope in the factory CreateServiceProvider() function rather than in the constructor (it should be more closer to what Microsoft DI does).

There was a previous PR (that I closed) similar to this one with less tests and a fix that didn't worked in some scenario, I clsed that and replaced with this one. I think some more changes can be made and a lot of intermediate commits can be squased.