### PR TITLE
Update Castle.Windsor.Extensions.DependencyInjection to support .NET8

### DIFF
--- a/.config/GitVersion.yml
+++ b/.config/GitVersion.yml
@@ -1,0 +1,5 @@
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}
+mode: ContinuousDeployment

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nswag.consolecore": {
+      "version": "14.0.0",
+      "commands": [
+        "nswag"
+      ]
+    },
+    "gitversion.tool": {
+      "version": "5.2.4",
+      "commands": [
+        "dotnet-gitversion"
+      ]
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ indent_size = 2
 [*.cs]
 indent_style = tab
 indent_size = 4
+csharp_new_line_before_open_brace = all

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,21 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "dotnet",
-    "isShellCommand": true,
     "args": [],
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
+                "build",
                 "${workspaceRoot}/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj"
             ],
-            "isBuildCommand": true,
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
         }
     ]
 }

--- a/.vscode/tasks.json.old
+++ b/.vscode/tasks.json.old
@@ -1,0 +1,16 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ Castle Windsor is a best of breed, mature Inversion of Control container availab
 
 See the [documentation](docs/README.md).
 
+## Considerations
+
+Castle.Windsor.Extensions.DependencyInjection try to make Microsoft Dependency Injection works with Castle.Windsor. We have some
+really different rules in the two world, one is the order of resolution exposed by the test Resolve_order_in_castle that shows
+how the two have two different strategies.
+
+1. Microsof DI want to resolve the last registered service
+2. Castle.Windsor want to resolve the first registered service.
+
+This is one of the point where the integration become painful, because it can happen that the very same service got resolved
+in two distinct way, depending on who is resolving the service.
+
+	The preferred solution is to understand who is registering the service and resolve everything accordingly.
+
+## I want to try everything locally.
+
+If you want to easily try a local compiled version on your project you can use the following trick.
+
+1. Add the GenerateAssemblyInfo to false on the project file
+1. Add an assemblyinfo.cs in Properties folder and add the [assembly: AssemblyVersion("6.0.0")] attribute to force the correct version
+1. Compile the project
+1. Copy into the local nuget cache, from the output folder of this project run
+
+```
+copy * %Uer Profile%\.nuget\packages\castle.windsor.extensions.dependencyinjection\6.0.x\lib\net8.0
+```
+
+This usually works.
+
 ## Releases
 
 See the [releases](https://github.com/castleproject/Windsor/releases).

--- a/build_without_wcf_tests.cmd
+++ b/build_without_wcf_tests.cmd
@@ -1,0 +1,18 @@
+@ECHO OFF
+REM ****************************************************************************
+REM Copyright 2004-2013 Castle Project - http://www.castleproject.org/
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM 
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM 
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM ****************************************************************************
+
+@call buildscripts\build_without_wcf_tests.cmd %*
+

--- a/buildscripts/build_without_wcf_tests.cmd
+++ b/buildscripts/build_without_wcf_tests.cmd
@@ -1,0 +1,83 @@
+@ECHO OFF
+REM ****************************************************************************
+REM Copyright 2004-2013 Castle Project - http://www.castleproject.org/
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM 
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM 
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM ****************************************************************************
+
+if "%1" == "" goto no_config 
+if "%1" NEQ "" goto set_config 
+
+:set_config
+SET Configuration=%1
+GOTO restore_packages
+
+:no_config
+SET Configuration=Release
+GOTO restore_packages
+
+:restore_packages
+dotnet restore ./tools/Explicit.NuGet.Versions/Explicit.NuGet.Versions.csproj
+dotnet restore ./buildscripts/BuildScripts.csproj
+dotnet restore ./src/Castle.Windsor/Castle.Windsor.csproj
+dotnet restore ./src/Castle.Facilities.Logging/Castle.Facilities.Logging.csproj
+dotnet restore ./src/Castle.Facilities.AspNet.SystemWeb/Castle.Facilities.AspNet.SystemWeb.csproj
+dotnet restore ./src/Castle.Facilities.AspNet.SystemWeb.Tests/Castle.Facilities.AspNet.SystemWeb.Tests.csproj
+dotnet restore ./src/Castle.Facilities.AspNet.Mvc/Castle.Facilities.AspNet.Mvc.csproj
+dotnet restore ./src/Castle.Facilities.AspNet.Mvc.Tests/Castle.Facilities.AspNet.Mvc.Tests.csproj
+dotnet restore ./src/Castle.Facilities.AspNet.WebApi/Castle.Facilities.AspNet.WebApi.csproj
+dotnet restore ./src/Castle.Facilities.AspNet.WebApi.Tests/Castle.Facilities.AspNet.WebApi.Tests.csproj
+dotnet restore ./src/Castle.Facilities.AspNetCore/Castle.Facilities.AspNetCore.csproj
+dotnet restore ./src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
+dotnet restore ./src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
+dotnet restore ./src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
+dotnet restore ./src/Castle.Windsor.Extensions.Hosting/Castle.Windsor.Extensions.Hosting.csproj
+dotnet restore ./src/Castle.Facilities.WcfIntegration/Castle.Facilities.WcfIntegration.csproj
+dotnet restore ./src/Castle.Facilities.WcfIntegration.Demo/Castle.Facilities.WcfIntegration.Demo.csproj
+dotnet restore ./src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
+dotnet restore ./src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+
+
+GOTO build
+
+:build
+dotnet build ./tools/Explicit.NuGet.Versions/Explicit.NuGet.Versions.sln
+dotnet build Castle.Windsor.sln -c %Configuration%
+GOTO test
+
+:test
+
+echo -------------
+echo Running Tests
+echo -------------
+
+dotnet test src\Castle.Windsor.Tests || exit /b 1
+dotnet test src\Castle.Windsor.Extensions.DependencyInjection.Tests || exit /b 1
+dotnet test src\Castle.Facilities.AspNetCore.Tests || exit /b 1
+dotnet test src\Castle.Facilities.AspNet.SystemWeb.Tests || exit /b 1
+dotnet test src\Castle.Facilities.AspNet.Mvc.Tests || exit /b 1
+dotnet test src\Castle.Facilities.AspNet.WebApi.Tests || exit /b 1
+rem dotnet test src\Castle.Facilities.WcfIntegration.Tests || exit /b 1
+
+GOTO nuget_explicit_versions
+
+:nuget_explicit_versions
+
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.windsor"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.loggingfacility"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.windsor.extensions.dependencyinjection"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.windsor.extensions.hosting"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnetcore"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnet.mvc"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnet.webapi"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.facilities.aspnet.systemweb"
+.\tools\Explicit.NuGet.Versions\build\nev.exe ".\build" "castle.wcfintegrationfacility"

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -4,7 +4,7 @@
 		<NoWarn>$(NoWarn);CS1591;NU5048</NoWarn>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/castleproject/Windsor</RepositoryUrl>
-		<BuildVersion>6.0.0</BuildVersion>
+		<BuildVersion>0.0.0</BuildVersion>
 		<BuildVersion Condition="'$(APPVEYOR_BUILD_VERSION)'!=''">$(APPVEYOR_BUILD_VERSION)</BuildVersion>
 		<BuildVersionMajor>$(BuildVersion.Split('.')[0])</BuildVersionMajor>
 		<BuildVersionNoSuffix>$(BuildVersion.Split('-')[0])</BuildVersionNoSuffix>
@@ -18,7 +18,7 @@
 		<Product>Castle Windsor</Product>
 		<FileVersion>$(BuildVersionNoSuffix)</FileVersion>
 		<VersionPrefix>$(BuildVersion)</VersionPrefix>
-		<AssemblyVersion>6.0.0.0</AssemblyVersion>
+		<AssemblyVersion>$(BuildVersionMajor).0.0</AssemblyVersion>
 		<AssemblyTitle>Castle Windsor is best of breed, mature Inversion of Control container available for .NET</AssemblyTitle>
 		<Authors>Castle Project Contributors</Authors>
 		<PackageProjectUrl>http://www.castleproject.org/projects/windsor/</PackageProjectUrl>

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -4,7 +4,7 @@
 		<NoWarn>$(NoWarn);CS1591;NU5048</NoWarn>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/castleproject/Windsor</RepositoryUrl>
-		<BuildVersion>0.0.0</BuildVersion>
+		<BuildVersion>6.0.0</BuildVersion>
 		<BuildVersion Condition="'$(APPVEYOR_BUILD_VERSION)'!=''">$(APPVEYOR_BUILD_VERSION)</BuildVersion>
 		<BuildVersionMajor>$(BuildVersion.Split('.')[0])</BuildVersionMajor>
 		<BuildVersionNoSuffix>$(BuildVersion.Split('-')[0])</BuildVersionNoSuffix>
@@ -18,7 +18,7 @@
 		<Product>Castle Windsor</Product>
 		<FileVersion>$(BuildVersionNoSuffix)</FileVersion>
 		<VersionPrefix>$(BuildVersion)</VersionPrefix>
-		<AssemblyVersion>$(BuildVersionMajor).0.0</AssemblyVersion>
+		<AssemblyVersion>6.0.0.0</AssemblyVersion>
 		<AssemblyTitle>Castle Windsor is best of breed, mature Inversion of Control container available for .NET</AssemblyTitle>
 		<Authors>Castle Project Contributors</Authors>
 		<PackageProjectUrl>http://www.castleproject.org/projects/windsor/</PackageProjectUrl>

--- a/src/Castle.Facilities.AspNet.Mvc.Tests/Castle.Facilities.AspNet.Mvc.Tests.csproj
+++ b/src/Castle.Facilities.AspNet.Mvc.Tests/Castle.Facilities.AspNet.Mvc.Tests.csproj
@@ -15,11 +15,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
 		<PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Facilities.AspNet.SystemWeb.Tests/Castle.Facilities.AspNet.SystemWeb.Tests.csproj
+++ b/src/Castle.Facilities.AspNet.SystemWeb.Tests/Castle.Facilities.AspNet.SystemWeb.Tests.csproj
@@ -19,10 +19,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Facilities.AspNet.WebApi.Tests/Castle.Facilities.AspNet.WebApi.Tests.csproj
+++ b/src/Castle.Facilities.AspNet.WebApi.Tests/Castle.Facilities.AspNet.WebApi.Tests.csproj
@@ -15,11 +15,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
 		<PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
+++ b/src/Castle.Facilities.AspNetCore.Tests/Castle.Facilities.AspNetCore.Tests.csproj
@@ -7,8 +7,8 @@
 	<ItemGroup>
 		<!-- This is an intentional upgrade to NUnit. This is the solution for https://github.com/castleproject/Windsor/issues/243 once we upgrade NUnit and make dotnet test a first class citizen-->
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.0.2" />

--- a/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
+++ b/src/Castle.Facilities.WcfIntegration.Tests/Castle.Facilities.WcfIntegration.Tests.csproj
@@ -12,9 +12,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
@@ -27,6 +27,14 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/Castle.Windsor.Extensions.DependencyInjection.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.assert" Version="2.4.2" />

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/CustomAssumptionTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/CustomAssumptionTests.cs
@@ -1,7 +1,10 @@
 ﻿#if NET8_0_OR_GREATER
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Tests
@@ -36,28 +39,232 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			Assert.IsType<AnotherTestService>(keyedServices.Last());
 		}
 
+		[Fact]
+		public void Scoped_keyed_service_resolved_by_thread_outside_scope()
+		{
+			Boolean stop = false;
+			Boolean shouldResolve = false;
+			ITestService resolvedInThread = null;
+			var thread = new Thread(_ =>
+			{
+				while (!stop)
+				{
+					Thread.Sleep(100);
+					if (shouldResolve)
+					{
+						stop = true;
+						resolvedInThread = _serviceProvider.GetRequiredKeyedService<ITestService>("porcodio");
+					}
+				}
+			});
+			thread.Start();
+
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddKeyedScoped<ITestService, TestService>("porcodio");
+			_serviceProvider = BuildServiceProvider(serviceCollection);
+
+			//resolved outside scope
+			ITestService resolvedOutsideScope = _serviceProvider.GetRequiredKeyedService<ITestService>("porcodio");
+
+			// resolve in scope
+			ITestService resolvedInScope;
+			using (var scope = _serviceProvider.CreateScope())
+			{
+				resolvedInScope = scope.ServiceProvider.GetRequiredKeyedService<ITestService>("porcodio");
+			}
+
+			shouldResolve = true;
+			//now wait for the original thread to finish
+			thread.Join(1000 * 10);
+			Assert.NotNull(resolvedInThread);
+			Assert.NotNull(resolvedOutsideScope);
+			Assert.NotNull(resolvedInScope);
+
+			Assert.NotEqual(resolvedInScope, resolvedOutsideScope);
+			Assert.NotEqual(resolvedInScope, resolvedInThread);
+			Assert.Equal(resolvedOutsideScope, resolvedInThread);
+		}
+
+		[Fact]
+		public void Scoped_service_resolved_outside_scope()
+		{
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddScoped<ITestService, TestService>();
+			_serviceProvider = BuildServiceProvider(serviceCollection);
+
+			//resolved outside scope
+			ITestService resolvedOutsideScope = _serviceProvider.GetRequiredService<ITestService>();
+			Assert.NotNull(resolvedOutsideScope);
+
+			// resolve in scope
+			ITestService resolvedInScope;
+			using (var scope = _serviceProvider.CreateScope())
+			{
+				resolvedInScope = scope.ServiceProvider.GetRequiredService<ITestService>();
+			}
+			Assert.NotNull(resolvedInScope);
+			Assert.NotEqual(resolvedInScope, resolvedOutsideScope);
+
+			ITestService resolvedAgainOutsideScope = _serviceProvider.GetRequiredService<ITestService>();
+			Assert.NotNull(resolvedAgainOutsideScope);
+			Assert.Equal(resolvedOutsideScope, resolvedAgainOutsideScope);
+		}
+
+		[Fact]
+		public void Scoped_service_resolved_outside_scope_in_another_thread()
+		{
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddScoped<ITestService, TestService>();
+			_serviceProvider = BuildServiceProvider(serviceCollection);
+
+			var task = Task.Run(() =>
+			{
+				//resolved outside scope
+				ITestService resolvedOutsideScope = _serviceProvider.GetRequiredService<ITestService>();
+				Assert.NotNull(resolvedOutsideScope);
+
+				// resolve in scope
+				ITestService resolvedInScope;
+				using (var scope = _serviceProvider.CreateScope())
+				{
+					resolvedInScope = scope.ServiceProvider.GetRequiredService<ITestService>();
+				}
+				Assert.NotNull(resolvedInScope);
+				Assert.NotEqual(resolvedInScope, resolvedOutsideScope);
+
+				ITestService resolvedAgainOutsideScope = _serviceProvider.GetRequiredService<ITestService>();
+				Assert.NotNull(resolvedAgainOutsideScope);
+				Assert.Equal(resolvedOutsideScope, resolvedAgainOutsideScope);
+				return true;
+			});
+
+			Assert.True(task.Result);
+		}
+
+		[Fact]
+		public async void Scoped_service_resolved_outside_scope_in_another_unsafe_thread()
+		{
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddScoped<ITestService, TestService>();
+			_serviceProvider = BuildServiceProvider(serviceCollection);
+
+			var tsc = new TaskCompletionSource();
+			var worker = new QueueUserWorkItemWorker(_serviceProvider, tsc);
+			ThreadPool.UnsafeQueueUserWorkItem(worker, false);
+			await tsc.Task;
+
+			Assert.Null(worker.ExecuteException);
+			Assert.NotNull(worker.ResolvedOutsideScope);
+			Assert.NotNull(worker.ResolvedInScope);
+			Assert.NotEqual(worker.ResolvedInScope, worker.ResolvedOutsideScope);
+		}
+
+		[Fact]
+		public async void Simulate_async_timer_without_wait()
+		{
+			Boolean stop = false;
+			Boolean shouldResolve = false;
+			ITestService resolvedInThread = null;
+			async Task ExecuteAsync()
+			{
+				while (!stop)
+				{
+					await Task.Delay(100);
+					if (shouldResolve)
+					{
+						stop = true;
+						resolvedInThread = _serviceProvider.GetService<ITestService>();
+					}
+				}
+			}
+			//fire and forget
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+			var task = ExecuteAsync();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+			await Task.Delay(500);
+
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddScoped<ITestService, TestService>();
+			_serviceProvider = BuildServiceProvider(serviceCollection);
+
+			//resolved outside scope
+			ITestService resolvedOutsideScope = _serviceProvider.GetRequiredService<ITestService>();
+
+			// resolve in scope
+			ITestService resolvedInScope;
+			using (var scope = _serviceProvider.CreateScope())
+			{
+				resolvedInScope = scope.ServiceProvider.GetRequiredService<ITestService>();
+			}
+
+			shouldResolve = true;
+			await task;
+			Assert.NotNull(resolvedInThread);
+			Assert.NotNull(resolvedOutsideScope);
+			Assert.NotNull(resolvedInScope);
+
+			Assert.NotEqual(resolvedInScope, resolvedOutsideScope);
+			Assert.NotEqual(resolvedInScope, resolvedInThread);
+			Assert.Equal(resolvedOutsideScope, resolvedInThread);
+		}
+
+		private class QueueUserWorkItemWorker : IThreadPoolWorkItem
+		{
+			private readonly IServiceProvider _provider;
+			private readonly TaskCompletionSource _taskCompletionSource;
+
+			public QueueUserWorkItemWorker(IServiceProvider provider, TaskCompletionSource taskCompletionSource)
+			{
+				_provider = provider;
+				_taskCompletionSource = taskCompletionSource;
+			}
+
+			public ITestService ResolvedOutsideScope { get; private set; }
+			public ITestService ResolvedInScope { get; private set; }
+			public Exception ExecuteException { get; private set; }
+
+			public void Execute()
+			{
+				try
+				{
+					ResolvedOutsideScope = _provider.GetService<ITestService>();
+					using (var scope = _provider.CreateScope())
+					{
+						ResolvedInScope = scope.ServiceProvider.GetRequiredService<ITestService>();
+					}
+				}
+				catch (Exception ex)
+				{
+					ExecuteException = ex;
+				}
+
+				_taskCompletionSource.SetResult();
+			}
+		}
+
 		protected abstract IServiceCollection GetServiceCollection();
 
 		protected abstract IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection);
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // Dispose managed resources
-                if (_serviceProvider is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
-            }
-            // Dispose unmanaged resources
-        }
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				// Dispose managed resources
+				if (_serviceProvider is IDisposable disposable)
+				{
+					disposable.Dispose();
+				}
+			}
+			// Dispose unmanaged resources
+		}
 	}
 
 	public class RealCustomAssumptionTests : CustomAssumptionTests
@@ -75,6 +282,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 
 	public class CastleWindsorCustomAssumptionTests : CustomAssumptionTests
 	{
+		private IWindsorContainer _container;
+
 		protected override IServiceCollection GetServiceCollection()
 		{
 			return new TestServiceCollection();
@@ -83,8 +292,64 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		protected override IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection)
 		{
 			var factory = new WindsorServiceProviderFactory();
-			var container = factory.CreateBuilder(serviceCollection);
-			return factory.CreateServiceProvider(container);
+			_container = factory.CreateBuilder(serviceCollection);
+			return factory.CreateServiceProvider(_container);
+		}
+
+		[Fact]
+		public void Try_to_resolve_scoped_directly_with_castle_windsor_container()
+		{
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddScoped<ITestService, TestService>();
+			var provider = BuildServiceProvider(serviceCollection);
+
+			//resolved outside scope
+			ITestService resolvedOutsideScope = _container.Resolve<ITestService>();
+			Assert.NotNull(resolvedOutsideScope);
+
+			// resolve in scope
+			ITestService resolvedInScope;
+			using (var scope = provider.CreateScope())
+			{
+				resolvedInScope = _container.Resolve<ITestService>();
+			}
+			Assert.NotNull(resolvedInScope);
+			Assert.NotEqual(resolvedInScope, resolvedOutsideScope);
+
+			ITestService resolvedAgainOutsideScope = _container.Resolve<ITestService>();
+			Assert.NotNull(resolvedAgainOutsideScope);
+			Assert.Equal(resolvedOutsideScope, resolvedAgainOutsideScope);
+		}
+
+		[Fact]
+		public void TryToResolveScopedInOtherThread()
+		{
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddScoped<ITestService, TestService>();
+			var provider = BuildServiceProvider(serviceCollection);
+
+			var task = Task.Run(() =>
+			{
+				//resolved outside scope
+				ITestService resolvedOutsideScope = _container.Resolve<ITestService>();
+				Assert.NotNull(resolvedOutsideScope);
+
+				// resolve in scope
+				ITestService resolvedInScope;
+				using (var scope = provider.CreateScope())
+				{
+					resolvedInScope = _container.Resolve<ITestService>();
+				}
+				Assert.NotNull(resolvedInScope);
+				Assert.NotEqual(resolvedInScope, resolvedOutsideScope);
+
+				ITestService resolvedAgainOutsideScope = _container.Resolve<ITestService>();
+				Assert.NotNull(resolvedAgainOutsideScope);
+				Assert.Equal(resolvedOutsideScope, resolvedAgainOutsideScope);
+				return true;
+			});
+
+			Assert.True(task.Result);
 		}
 	}
 

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/CustomAssumptionTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/CustomAssumptionTests.cs
@@ -1,0 +1,103 @@
+﻿#if NET8_0_OR_GREATER
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests
+{
+	public abstract class CustomAssumptionTests : IDisposable
+	{
+		private IServiceProvider _serviceProvider;
+
+		[Fact]
+		public void Resolve_All()
+		{
+			var serviceCollection = GetServiceCollection();
+			serviceCollection.AddKeyedSingleton<ITestService, TestService>("one");
+			serviceCollection.AddKeyedSingleton<ITestService, AnotherTestService>("one");
+			serviceCollection.AddTransient<ITestService, AnotherTestService>();
+			_serviceProvider = BuildServiceProvider(serviceCollection);
+
+			// resolve all non-keyed services
+			var services = _serviceProvider.GetServices<ITestService>();
+			Assert.Single(services);
+			Assert.IsType<AnotherTestService>(services.First());
+
+			// passing "null" as the key should return all non-keyed services
+			var keyedServices = _serviceProvider.GetKeyedServices<ITestService>(null);
+			Assert.Single(keyedServices);
+			Assert.IsType<AnotherTestService>(keyedServices.First());
+
+			// resolve all keyed services
+			keyedServices = _serviceProvider.GetKeyedServices<ITestService>("one");
+			Assert.Equal(2, keyedServices.Count());
+			Assert.IsType<TestService>(keyedServices.First());
+			Assert.IsType<AnotherTestService>(keyedServices.Last());
+		}
+
+		protected abstract IServiceCollection GetServiceCollection();
+
+		protected abstract IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Dispose managed resources
+                if (_serviceProvider is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+            // Dispose unmanaged resources
+        }
+	}
+
+	public class RealCustomAssumptionTests : CustomAssumptionTests
+	{
+		protected override IServiceCollection GetServiceCollection()
+		{
+			return new RealTestServiceCollection();
+		}
+
+		protected override IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection)
+		{
+			return serviceCollection.BuildServiceProvider();
+		}
+	}
+
+	public class CastleWindsorCustomAssumptionTests : CustomAssumptionTests
+	{
+		protected override IServiceCollection GetServiceCollection()
+		{
+			return new TestServiceCollection();
+		}
+
+		protected override IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection)
+		{
+			var factory = new WindsorServiceProviderFactory();
+			var container = factory.CreateBuilder(serviceCollection);
+			return factory.CreateServiceProvider(container);
+		}
+	}
+
+	internal class TestService : ITestService
+	{
+	}
+
+	internal class AnotherTestService : ITestService
+	{
+	}
+
+	internal interface ITestService
+	{
+	}
+}
+#endif

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/CustomAssumptionTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/CustomAssumptionTests.cs
@@ -282,6 +282,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 
 	public class CastleWindsorCustomAssumptionTests : CustomAssumptionTests
 	{
+		private WindsorServiceProviderFactory _factory;
 		private IWindsorContainer _container;
 
 		protected override IServiceCollection GetServiceCollection()
@@ -291,9 +292,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 
 		protected override IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection)
 		{
-			var factory = new WindsorServiceProviderFactory();
-			_container = factory.CreateBuilder(serviceCollection);
-			return factory.CreateServiceProvider(_container);
+			_factory = new WindsorServiceProviderFactory();
+			_container = _factory.CreateBuilder(serviceCollection);
+			return _factory.CreateServiceProvider(_container);
 		}
 
 		[Fact]
@@ -350,6 +351,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			});
 
 			Assert.True(task.Result);
+		}
+
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			if (disposing)
+			{
+				_factory.Dispose();
+			}
 		}
 	}
 

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -13,6 +13,11 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 	{
 		#region Singleton
 
+		/* 
+		 * Singleton tests should never fail, given you have a container instance you should always
+		 * be able to resolve a singleton from it. 
+		 */
+
 		[Fact]
 		public async Task Can_Resolve_LifestyleSingleton_From_ServiceProvider()
 		{
@@ -51,6 +56,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -76,7 +84,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -91,6 +99,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -131,6 +142,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -156,7 +170,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -171,11 +185,19 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		#endregion
 
 		#region Scoped
+
+		/*
+		 * Scoped tests might fail if for whatever reason you do not have a current scope
+		 * (like when you run from Threadpool.UnsafeQueueUserWorkItem).
+		 */
 
 		[Fact]
 		public async Task Can_Resolve_LifestyleScoped_From_ServiceProvider()
@@ -215,6 +237,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -240,7 +265,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -255,8 +280,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
+		/// <summary>
+		/// This test succeeds because WindsorScopedServiceProvider captured the root scope on creation
+		/// and forced it to be current before service resolution.
+		/// Scoped is tied to the rootscope = potential memory leak.
+		/// </summary>
 		[Fact]
 		public async Task Can_Resolve_LifestyleScopedToNetServiceScope_From_ServiceProvider()
 		{
@@ -295,6 +328,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -320,7 +356,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -335,11 +371,25 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		#endregion
 
 		#region Transient
+
+		/*
+		 * Transient tests failure is questionable:
+		 * - if you have a container you should be able to resolve transient without a scope,
+		 *   but they might be tracked by the container itself (or the IServiceProvider)
+		 * - when windsor container is disposed all transient services are disposed as well
+		 * - when a IServiceProvider is disposed all transient services (created by it) are disposed as well
+		 * - problem is: we have una instance of a windsor container passed on to multiple instances of IServiceProvider
+		 *   one solution will be to tie the Transients to a scope, and the scope is tied to service provider
+		 *   when both of them are disposed, the transient services are disposed as well
+		 */
 
 		[Fact]
 		public async Task Can_Resolve_LifestyleTransient_From_ServiceProvider()
@@ -379,6 +429,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -404,7 +457,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -419,8 +472,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
+		/// <summary>
+		/// This test succeeds because WindsorScopedServiceProvider captured the root scope on creation
+		/// and forced it to be current before service resolution.
+		/// Transient is tied to the rootscope = potential memory leak.
+		/// </summary>
 		[Fact]
 		public async Task Can_Resolve_LifestyleNetTransient_From_ServiceProvider()
 		{
@@ -459,6 +520,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		[Fact]
@@ -484,7 +548,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				try
 				{
-					var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+					var actualUserService = container.Resolve<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex)
@@ -499,8 +563,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var task = tcs.Task;
 			IUserService result = await task;
 			Assert.NotNull(result);
+
+			(sp as IDisposable)?.Dispose();
+			container.Dispose();
 		}
 
 		#endregion
+
+		/*
+		 * Missing tests: we should also test what happens with injected IServiceProvider (what scope do they get?)
+		 * Injected IServiceProvider might or might not have a scope (it depends on AsyncLocal value).
+		 */
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -9,8 +9,41 @@ using Xunit;
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 {
-	public class ResolveFromThreadpoolUnsafe
+	[CollectionDefinition(nameof(DoNotParallelize), DisableParallelization = true)]
+	public class DoNotParallelize { }
+
+	/// <summary>
+	/// These is the original Castle Windsor Dependency Injection behavior.
+	/// </summary>
+	public class ResolveFromThreadpoolUnsafe_NetStatic: AbstractResolveFromThreadpoolUnsafe
 	{
+		public ResolveFromThreadpoolUnsafe_NetStatic() : base(false)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Mapping NetStatic to usual Singleton lifestyle.
+	/// </summary>
+	public class ResolveFromThreadpoolUnsafe_Singleton : AbstractResolveFromThreadpoolUnsafe
+	{
+		public ResolveFromThreadpoolUnsafe_Singleton() : base(true)
+		{
+		}
+	}
+
+	/// <summary>
+	/// relying on static state (WindsorDependencyInjectionOptions) is not good for tests
+	/// that might run in parallel, can lead to false positives / negatives.
+	/// </summary>
+	[Collection(nameof(DoNotParallelize))]
+	public abstract class AbstractResolveFromThreadpoolUnsafe
+	{
+		protected AbstractResolveFromThreadpoolUnsafe(bool mapNetStaticToSingleton)
+		{
+			WindsorDependencyInjectionOptions.MapNetStaticToSingleton = mapNetStaticToSingleton;
+		}
+
 		#region Singleton
 
 		/* 
@@ -147,6 +180,10 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			container.Dispose();
 		}
 
+		/// <summary>
+		/// This test will Succeed is we use standard Castle Windsor Singleton lifestyle instead of the custom
+		/// NetStatic lifestyle.
+		/// </summary>
 		[Fact]
 		public async Task Can_Resolve_LifestyleNetStatic_From_WindsorContainer()
 		{

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,0 +1,56 @@
+﻿using Castle.MicroKernel.Registration;
+using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests {
+	public class ResolveFromThreadpoolUnsafe {
+		[Fact]
+		public async Task Can_Resolve_From_ServiceProvider() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				Component.For<IUserService>().ImplementedBy<UserService>()
+			);
+
+			IServiceProvider sp = f.CreateServiceProvider(container);
+
+			var actualUserService = sp.GetService<IUserService>();
+			Assert.NotNull(actualUserService);
+
+			/*
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				// resolving using castle (without scopes) works
+				var actualUserService = container.Resolve<IUserService>(nameof(UserService));
+				Assert.NotNull(actualUserService);
+			}, null);
+			*/
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				try {
+					var actualUserService = sp.GetService<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,4 +1,5 @@
-﻿using Castle.MicroKernel.Lifestyle;
+﻿using Castle.MicroKernel;
+using Castle.MicroKernel.Lifestyle;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor.Extensions.DependencyInjection.Extensions;
 using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
@@ -512,8 +513,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			});
 
 			Assert.NotNull(ex);
-			Assert.IsType<InvalidOperationException>(ex);
-			Assert.StartsWith("No scope available", ex.Message);
+			Assert.IsType<ComponentResolutionException>(ex);
+			Assert.StartsWith("Could not obtain scope for component", ex.Message);
 
 			(sp as IDisposable)?.Dispose();
 			container.Dispose();
@@ -711,8 +712,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			});
 
 			Assert.NotNull(ex);
-			Assert.IsType<InvalidOperationException>(ex);
-			Assert.StartsWith("No scope available", ex.Message);
+			Assert.IsType<ComponentResolutionException>(ex);
+			Assert.StartsWith("Could not obtain scope for component", ex.Message);
 
 			(sp as IDisposable)?.Dispose();
 			container.Dispose();

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -30,11 +30,11 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		/// NetStatic lifestyle.
 		/// </summary>
 		[Fact]
-		public async Task Cannot_Resolve_LifestyleNetStatic_From_WindsorContainer_NoRootScopeAvailable()
+		public async Task Can_Resolve_LifestyleNetStatic_From_WindsorContainer_NoRootScopeAvailable()
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -68,14 +68,13 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			{
 				var task = tcs.Task;
 				IUserService result = await task;
-				// The test succeeds if we use standard Castle Windsor Singleton lifestyle instead of the custom NetStatic lifestyle.
+				//with the fix we can now use correctly a fallback for the root scope so we can access root scope even
+				//if we are outside of scope
 				Assert.NotNull(result);
 			});
 
 			// This test will fail if we use NetStatic lifestyle
-			Assert.NotNull(ex);
-			Assert.IsType<InvalidOperationException>(ex);
-			Assert.Equal("No root scope available.", ex.Message);
+			Assert.Null(ex);
 
 			(sp as IDisposable)?.Dispose();
 			container.Dispose();
@@ -315,7 +314,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -373,7 +372,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -432,7 +431,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -475,7 +474,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -540,7 +539,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -583,7 +582,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -631,7 +630,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(
@@ -674,7 +673,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 		{
 			var serviceProvider = new ServiceCollection();
 			var container = new WindsorContainer();
-			var f = new WindsorServiceProviderFactory(container);
+			using var f = new WindsorServiceProviderFactory(container);
 			f.CreateBuilder(serviceProvider);
 
 			container.Register(

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/ResolveFromThreadpoolUnsafe.cs
@@ -1,4 +1,5 @@
 ﻿using Castle.MicroKernel.Registration;
+using Castle.Windsor.Extensions.DependencyInjection.Extensions;
 using Castle.Windsor.Extensions.DependencyInjection.Tests.Components;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -38,6 +39,84 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests {
 			ThreadPool.UnsafeQueueUserWorkItem(state => {
 				try {
 					var actualUserService = sp.GetService<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public async Task Can_Resolve_From_CastleWindsor() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				// Component.For<IUserService>().ImplementedBy<UserService>().LifestyleNetTransient(),
+				Classes.FromThisAssembly().BasedOn<IUserService>().WithServiceAllInterfaces().LifestyleNetStatic()
+				);
+
+			IUserService actualUserService;
+			actualUserService = container.Resolve<IUserService>();
+			Assert.NotNull(actualUserService);
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				IUserService actualUserService = null;
+				try {
+					// resolving (with the underlying Castle Windsor, not using Service Provider) with a lifecycle that has an
+					// accessor that uses something that is AsyncLocal might be troublesome.
+					// the custom lifecycle accessor will kicks in, but noone assigns the Current scope (which is uninitialized)
+					actualUserService = container.Resolve<IUserService>();
+					Assert.NotNull(actualUserService);
+				}
+				catch (Exception ex) {
+					tcs.SetException(ex);
+					return;
+				}
+				tcs.SetResult(actualUserService);
+			}, null);
+
+			// Wait for the work item to complete.
+			var task = tcs.Task;
+			IUserService result = await task;
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public async Task Can_Resolve_From_ServiceProvider_cretaed_in_UnsafeQueueUserWorkItem() {
+
+			var serviceProvider = new ServiceCollection();
+			var container = new WindsorContainer();
+			var f = new WindsorServiceProviderFactory(container);
+			f.CreateBuilder(serviceProvider);
+
+			container.Register(
+				// Component.For<IUserService>().ImplementedBy<UserService>().LifestyleNetTransient(),
+				Classes.FromThisAssembly().BasedOn<IUserService>().WithServiceAllInterfaces().LifestyleNetStatic()
+				);
+
+			TaskCompletionSource<IUserService> tcs = new TaskCompletionSource<IUserService>();
+
+			ThreadPool.UnsafeQueueUserWorkItem(state => {
+				IUserService actualUserService = null;
+				try {
+					// creating a service provider here will be troublesome too
+					IServiceProvider sp = f.CreateServiceProvider(container);
+
+					actualUserService = sp.GetService<IUserService>();
 					Assert.NotNull(actualUserService);
 				}
 				catch (Exception ex) {

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/SkippableDependencyInjectionSpecificationTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/SkippableDependencyInjectionSpecificationTests.cs
@@ -23,14 +23,18 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 
+#if NET8_0_OR_GREATER
+using Microsoft.Extensions.DependencyInjection.Extensions;
+#endif
+
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
 	public abstract class SkippableDependencyInjectionSpecificationTests : DependencyInjectionSpecificationTests
 	{
-		public string[] SkippedTests => new[] { "SingletonServiceCanBeResolvedFromScope" };
+		public string[] SkippedTests => Array.Empty<string>();
 
 #if NET6_0_OR_GREATER
-		public override bool SupportsIServiceProviderIsService => false;
+		public override bool SupportsIServiceProviderIsService => true;
 #endif
 
 		protected sealed override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/TestServiceCollection.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/TestServiceCollection.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests
+{
+	internal sealed class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+	{
+	}
+
+	internal sealed class RealTestServiceCollection : ServiceCollection
+	{
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorKeyedDependencyInjectionSpecificationTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorKeyedDependencyInjectionSpecificationTests.cs
@@ -1,0 +1,124 @@
+﻿#if NET8_0_OR_GREATER
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Specification;
+using System;
+using Xunit;
+
+namespace Castle.Windsor.Extensions.DependencyInjection.Tests
+{
+	public class WindsorKeyedDependencyInjectionSpecificationTests : KeyedDependencyInjectionSpecificationTests
+	{
+		protected override IServiceProvider CreateServiceProvider(IServiceCollection collection)
+		{
+			if (collection is TestServiceCollection)
+			{
+				var factory = new WindsorServiceProviderFactory();
+				var container = factory.CreateBuilder(collection);
+				return factory.CreateServiceProvider(container);
+			}
+
+            return collection.BuildServiceProvider();
+		}
+
+		//[Fact]
+		//public void ResolveKeyedServiceSingletonInstanceWithAnyKey2()
+		//{
+		//	var serviceCollection = new ServiceCollection();
+		//	serviceCollection.AddKeyedSingleton<IService, Service>(KeyedService.AnyKey);
+
+		//	var provider = CreateServiceProvider(serviceCollection);
+
+		//	Assert.Null(provider.GetService<IService>());
+
+		//	var serviceKey1 = "some-key";
+		//	var svc1 = provider.GetKeyedService<IService>(serviceKey1);
+		//	Assert.NotNull(svc1);
+		//	Assert.Equal(serviceKey1, svc1.ToString());
+
+		//	var serviceKey2 = "some-other-key";
+		//	var svc2 = provider.GetKeyedService<IService>(serviceKey2);
+		//	Assert.NotNull(svc2);
+		//	Assert.Equal(serviceKey2, svc2.ToString());
+		//}
+
+		internal interface IService { }
+
+		internal class Service : IService
+		{
+			private readonly string _id;
+
+			public Service() => _id = Guid.NewGuid().ToString();
+
+			public Service([ServiceKey] string id) => _id = id;
+
+			public override string? ToString() => _id;
+		}
+
+		internal class OtherService
+		{
+			public OtherService(
+				[FromKeyedServices("service1")] IService service1,
+				[FromKeyedServices("service2")] IService service2)
+			{
+				Service1 = service1;
+				Service2 = service2;
+			}
+
+			public IService Service1 { get; }
+
+			public IService Service2 { get; }
+		}
+
+		public class FakeService : IFakeEveryService, IDisposable
+		{
+			public PocoClass Value { get; set; }
+
+			public bool Disposed { get; private set; }
+
+			public void Dispose()
+			{
+				if (Disposed)
+				{
+					throw new ObjectDisposedException(nameof(FakeService));
+				}
+
+				Disposed = true;
+			}
+		}
+
+		public interface IFakeEveryService :
+			IFakeService,
+			IFakeMultipleService,
+			IFakeScopedService
+		{
+		}
+
+		public interface IFakeMultipleService : IFakeService
+		{
+		}
+
+		public interface IFakeScopedService : IFakeService
+		{
+		}
+
+		public interface IFakeService
+		{
+		}
+
+		public class PocoClass
+		{
+		}
+	}
+
+	//public class WindsorKeyedDependencyInjectionSpecificationExplicitContainerTests : KeyedDependencyInjectionSpecificationTests
+	//{
+	//	protected override IServiceProvider CreateServiceProvider(IServiceCollection collection)
+	//	{
+	//		var factory = new WindsorServiceProviderFactory(new WindsorContainer());
+	//		var container = factory.CreateBuilder(collection);
+	//		return factory.CreateServiceProvider(container);
+	//	}
+	//}
+}
+
+#endif

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorKeyedDependencyInjectionSpecificationTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorKeyedDependencyInjectionSpecificationTests.cs
@@ -6,119 +6,43 @@ using Xunit;
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 {
-	public class WindsorKeyedDependencyInjectionSpecificationTests : KeyedDependencyInjectionSpecificationTests
+	public class WindsorKeyedDependencyInjectionSpecificationTests : KeyedDependencyInjectionSpecificationTests, IDisposable
 	{
+		private bool _disposedValue;
+		private WindsorServiceProviderFactory _factory;
+
 		protected override IServiceProvider CreateServiceProvider(IServiceCollection collection)
 		{
 			if (collection is TestServiceCollection)
 			{
-				var factory = new WindsorServiceProviderFactory();
-				var container = factory.CreateBuilder(collection);
-				return factory.CreateServiceProvider(container);
+				_factory = new WindsorServiceProviderFactory();
+				var container = _factory.CreateBuilder(collection);
+				return _factory.CreateServiceProvider(container);
 			}
 
             return collection.BuildServiceProvider();
 		}
 
-		//[Fact]
-		//public void ResolveKeyedServiceSingletonInstanceWithAnyKey2()
-		//{
-		//	var serviceCollection = new ServiceCollection();
-		//	serviceCollection.AddKeyedSingleton<IService, Service>(KeyedService.AnyKey);
-
-		//	var provider = CreateServiceProvider(serviceCollection);
-
-		//	Assert.Null(provider.GetService<IService>());
-
-		//	var serviceKey1 = "some-key";
-		//	var svc1 = provider.GetKeyedService<IService>(serviceKey1);
-		//	Assert.NotNull(svc1);
-		//	Assert.Equal(serviceKey1, svc1.ToString());
-
-		//	var serviceKey2 = "some-other-key";
-		//	var svc2 = provider.GetKeyedService<IService>(serviceKey2);
-		//	Assert.NotNull(svc2);
-		//	Assert.Equal(serviceKey2, svc2.ToString());
-		//}
-
-		internal interface IService { }
-
-		internal class Service : IService
+		protected virtual void Dispose(bool disposing)
 		{
-			private readonly string _id;
-
-			public Service() => _id = Guid.NewGuid().ToString();
-
-			public Service([ServiceKey] string id) => _id = id;
-
-			public override string? ToString() => _id;
-		}
-
-		internal class OtherService
-		{
-			public OtherService(
-				[FromKeyedServices("service1")] IService service1,
-				[FromKeyedServices("service2")] IService service2)
+			if (!_disposedValue)
 			{
-				Service1 = service1;
-				Service2 = service2;
-			}
-
-			public IService Service1 { get; }
-
-			public IService Service2 { get; }
-		}
-
-		public class FakeService : IFakeEveryService, IDisposable
-		{
-			public PocoClass Value { get; set; }
-
-			public bool Disposed { get; private set; }
-
-			public void Dispose()
-			{
-				if (Disposed)
+				if (disposing)
 				{
-					throw new ObjectDisposedException(nameof(FakeService));
+					_factory?.Dispose();
 				}
 
-				Disposed = true;
+				_disposedValue = true;
 			}
 		}
 
-		public interface IFakeEveryService :
-			IFakeService,
-			IFakeMultipleService,
-			IFakeScopedService
+		public void Dispose()
 		{
-		}
-
-		public interface IFakeMultipleService : IFakeService
-		{
-		}
-
-		public interface IFakeScopedService : IFakeService
-		{
-		}
-
-		public interface IFakeService
-		{
-		}
-
-		public class PocoClass
-		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
 		}
 	}
-
-	//public class WindsorKeyedDependencyInjectionSpecificationExplicitContainerTests : KeyedDependencyInjectionSpecificationTests
-	//{
-	//	protected override IServiceProvider CreateServiceProvider(IServiceCollection collection)
-	//	{
-	//		var factory = new WindsorServiceProviderFactory(new WindsorContainer());
-	//		var container = factory.CreateBuilder(collection);
-	//		return factory.CreateServiceProvider(container);
-	//	}
-	//}
 }
 
 #endif

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorKeyedDependencyInjectionSpecificationTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorKeyedDependencyInjectionSpecificationTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Specification;
 using System;
-using Xunit;
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 {

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
@@ -21,13 +21,36 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 	using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 	using Xunit;
 
-	public class WindsorScopedServiceProviderCustomWindsorContainerTests : SkippableDependencyInjectionSpecificationTests
+	public class WindsorScopedServiceProviderCustomWindsorContainerTests : SkippableDependencyInjectionSpecificationTests, IDisposable
 	{
+		private bool _disposedValue;
+		private WindsorServiceProviderFactory _factory;
+
 		protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
 		{
-			var factory = new WindsorServiceProviderFactory(new WindsorContainer());
-			var container = factory.CreateBuilder(serviceCollection);
-			return factory.CreateServiceProvider(container);
+			_factory = new WindsorServiceProviderFactory(new WindsorContainer());
+			var container = _factory.CreateBuilder(serviceCollection);
+			return _factory.CreateServiceProvider(container);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					_factory?.Dispose();
+				}
+
+				_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
 		}
 
 #if NET6_0_OR_GREATER

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
@@ -15,9 +15,11 @@
 namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 {
 	using System;
-
+	using System.Collections.Generic;
 	using Microsoft.Extensions.DependencyInjection;
 	using Microsoft.Extensions.DependencyInjection.Specification;
+	using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+	using Xunit;
 
 	public class WindsorScopedServiceProviderCustomWindsorContainerTests : SkippableDependencyInjectionSpecificationTests
 	{
@@ -27,5 +29,10 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			var container = factory.CreateBuilder(serviceCollection);
 			return factory.CreateServiceProvider(container);
 		}
+
+#if NET6_0_OR_GREATER
+#endif
+
 	}
+
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
@@ -21,6 +21,14 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 	using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 	using Xunit;
 
+	/// <summary>
+	/// This test inherits from a test class of the framework that contains a set of base tests to verify various assumption
+	/// that must be satisfied by DependencyInjection.
+	/// To debug a single test, open the corresponding test in dotnet/runtime repository,
+	/// then copy the test here, change name and execute with debugging etc etc.
+	/// This helps because source link support seems to be not to easy to use from the test runner
+	/// and this tricks makes everything really simpler.
+	/// </summary>
 	public class WindsorScopedServiceProviderCustomWindsorContainerTests : SkippableDependencyInjectionSpecificationTests, IDisposable
 	{
 		private bool _disposedValue;
@@ -52,33 +60,5 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			Dispose(disposing: true);
 			GC.SuppressFinalize(this);
 		}
-
-		///// <summary>
-		///// To verify when a single test failed, open the corresponding test in dotnet/runtime repository,
-		///// then copy the test here, change name and execute with debugging etc etc.
-		///// This helps because source link support seems to be not to easy to use from the test runner
-		///// and this tricks makes everything really simpler.
-		///// </summary>
-		//[Fact]
-		//public void ClosedServicesPreferredOverOpenGenericServices_custom()
-		//{
-		//	// Arrange
-		//	var collection = new TestServiceCollection();
-		//	collection.AddTransient(typeof(IFakeOpenGenericService<PocoClass>), typeof(FakeService));
-		//	collection.AddTransient(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>));
-		//	collection.AddSingleton<PocoClass>();
-		//	var provider = CreateServiceProvider(collection);
-
-		//	// Act
-		//	var service = provider.GetService<IFakeOpenGenericService<PocoClass>>();
-
-		//	// Assert
-		//	Assert.IsType<FakeService>(service);
-		//}
-
-#if NET6_0_OR_GREATER
-#endif
-
 	}
-
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderCustomWindsorContainerTests.cs
@@ -53,6 +53,29 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 			GC.SuppressFinalize(this);
 		}
 
+		///// <summary>
+		///// To verify when a single test failed, open the corresponding test in dotnet/runtime repository,
+		///// then copy the test here, change name and execute with debugging etc etc.
+		///// This helps because source link support seems to be not to easy to use from the test runner
+		///// and this tricks makes everything really simpler.
+		///// </summary>
+		//[Fact]
+		//public void ClosedServicesPreferredOverOpenGenericServices_custom()
+		//{
+		//	// Arrange
+		//	var collection = new TestServiceCollection();
+		//	collection.AddTransient(typeof(IFakeOpenGenericService<PocoClass>), typeof(FakeService));
+		//	collection.AddTransient(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>));
+		//	collection.AddSingleton<PocoClass>();
+		//	var provider = CreateServiceProvider(collection);
+
+		//	// Act
+		//	var service = provider.GetService<IFakeOpenGenericService<PocoClass>>();
+
+		//	// Assert
+		//	Assert.IsType<FakeService>(service);
+		//}
+
 #if NET6_0_OR_GREATER
 #endif
 

--- a/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderTests.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection.Tests/WindsorScopedServiceProviderTests.cs
@@ -19,13 +19,36 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Tests
 	using Microsoft.Extensions.DependencyInjection;
 	using Microsoft.Extensions.DependencyInjection.Specification;
 
-	public class WindsorScopedServiceProviderTests : SkippableDependencyInjectionSpecificationTests
+	public class WindsorScopedServiceProviderTests : SkippableDependencyInjectionSpecificationTests, IDisposable
 	{
+		private bool _disposedValue;
+		private WindsorServiceProviderFactory _factory;
+
 		protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
 		{
-			var factory = new WindsorServiceProviderFactory();
-			var container = factory.CreateBuilder(serviceCollection);
-			return factory.CreateServiceProvider(container);
+			_factory = new WindsorServiceProviderFactory();
+			var container = _factory.CreateBuilder(serviceCollection);
+			return _factory.CreateServiceProvider(container);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					_factory?.Dispose();
+				}
+
+				_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <Import Project="..\..\buildscripts\common.props"></Import>
@@ -29,6 +29,12 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
 	</ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+  </ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Castle.Windsor" Version="6.0.0" />

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
@@ -31,6 +31,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />
+	  <PackageReference Include="Castle.Windsor" Version="6.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="Castle.Windsor" Version="6.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Castle.Windsor\Castle.Windsor.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
@@ -16,7 +16,6 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<AssemblyName>Castle.Windsor.Extensions.DependencyInjection</AssemblyName>
 		<RootNamespace>Castle.Windsor.Extensions.DependencyInjection</RootNamespace>
-		<RootNamespace>Castle.Windsor.Extensions.DependencyInjection</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Castle.Windsor.Extensions.DependencyInjection.csproj
@@ -16,6 +16,7 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<AssemblyName>Castle.Windsor.Extensions.DependencyInjection</AssemblyName>
 		<RootNamespace>Castle.Windsor.Extensions.DependencyInjection</RootNamespace>
+		<RootNamespace>Castle.Windsor.Extensions.DependencyInjection</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Definitions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Definitions.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	internal static class IsExternalInit { }
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/ServiceDescriptorExtensions.cs
@@ -18,14 +18,16 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 
 	public static class ServiceDescriptorExtensions
 	{
-		public static IRegistration CreateWindsorRegistration(this Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		public static IRegistration CreateWindsorRegistration(
+			this Microsoft.Extensions.DependencyInjection.ServiceDescriptor service,
+			IWindsorContainer windsorContainer)
 		{
 			if (service.ServiceType.ContainsGenericParameters)
 			{
-				return RegistrationAdapter.FromOpenGenericServiceDescriptor(service);
+				return RegistrationAdapter.FromOpenGenericServiceDescriptor(service, windsorContainer);
 			}
 
-			return RegistrationAdapter.FromServiceDescriptor(service);
+			return RegistrationAdapter.FromServiceDescriptor(service, windsorContainer);
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
@@ -49,10 +49,13 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 		/// <typeparam name="TService"></typeparam>
 		public static ComponentRegistration<TService> NetStatic<TService>(this LifestyleGroup<TService> lifestyle) where TService : class
 		{
-			//return lifestyle.Singleton;
-			// I don't think we need this lifestyle at all, usual Singleton should be good
-			// also we don't need the whole rootscope thing a normal scope set as current should be enough
+			// I don't think we need this lifestyle at all, usual Singleton should be good enough;
+			// also we maybe don't need the whole rootscope thing. A normal scope set as current should be enough
 			// otherwise we should revert to static rootscope
+			if (WindsorDependencyInjectionOptions.MapNetStaticToSingleton)
+			{
+				return lifestyle.Singleton;
+			}
 			return lifestyle
 				.Scoped<ExtensionContainerRootScopeAccessor>();
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Extensions/WindsorExtensions.cs
@@ -49,6 +49,10 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Extensions
 		/// <typeparam name="TService"></typeparam>
 		public static ComponentRegistration<TService> NetStatic<TService>(this LifestyleGroup<TService> lifestyle) where TService : class
 		{
+			//return lifestyle.Singleton;
+			// I don't think we need this lifestyle at all, usual Singleton should be good
+			// also we don't need the whole rootscope thing a normal scope set as current should be enough
+			// otherwise we should revert to static rootscope
 			return lifestyle
 				.Scoped<ExtensionContainerRootScopeAccessor>();
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/KeyedRegistrationHelper.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/KeyedRegistrationHelper.cs
@@ -1,0 +1,209 @@
+﻿
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Resources;
+
+namespace Castle.Windsor.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// Microsoft Dependency Injection with keyed registeration uses keys
+	/// of type object, while castle has only string keys, we need to generate
+	/// a new key for each registration to fix this impedance mismatch
+	/// </summary>
+	internal class KeyedRegistrationHelper
+	{
+		/// <summary>
+		/// We need to keep tracks of all registration of a given key, we can have more than one service registered with a specific
+		/// key so when the caller want to resolve with a key we can know which service to resolve. Internally we generate a unique
+		/// string to register the object inside castle so we can easily resolve by name.
+		/// </summary>
+		/// <param name="Key">The key used to register the service</param>
+		/// <param name="ServiceDescriptor">Original Service Descriptor used to perform the registration</param>
+		/// <param name="CastleRegistrationKey">The name used inside castle to register the service.</param>
+		/// <param name="ServiceKeyParameterName">If the constructor has one parameter with the framework attribute ServiceKey we are
+		/// saving into this property the name of the parameter</param>
+		internal record KeyedRegistration(
+			object Key,
+			ServiceDescriptor ServiceDescriptor,
+			string CastleRegistrationKey,
+			string ServiceKeyParameterName)
+		{
+			/// <summary>
+			/// Resolve using the current key for castle.
+			/// </summary>
+			/// <param name="container">Container used to resolve</param>
+			/// <param name="currentKey">The current key used to resolve the service, this happens because if you use the generic
+			/// key we need to use the one used for the resolution. In can be null, in this scenario we will use the original
+			/// key used for the registration</param>
+			/// <returns></returns>
+			internal object Resolve(IWindsorContainer container, object currentKey = null)
+			{
+				//Support the parameter in constructor that want key to be injected
+				if (ServiceKeyParameterName != null)
+				{
+					var argumentParameters = new Dictionary<string, object>()
+					{
+						[ServiceKeyParameterName] = currentKey ?? Key
+					};
+					return container.Resolve(CastleRegistrationKey, ServiceDescriptor.ServiceType, argumentParameters);
+				}
+				return container.Resolve(CastleRegistrationKey, ServiceDescriptor.ServiceType);
+			}
+		}
+
+		/// <summary>
+		/// For each key we can have more than one service registered, this allows us to resolve the correct service. Also you can
+		/// resolve all the interfaces registered with a specific key.
+		/// </summary>
+		private readonly ConcurrentDictionary<object, List<KeyedRegistration>> _keyToRegistrationMap = new();
+
+		private readonly ConcurrentDictionary<Type, List<KeyedRegistration>> _typeToRegistrationMap = new();
+
+		private static readonly ConcurrentDictionary<IWindsorContainer, KeyedRegistrationHelper> _keyedRegistrations = new();
+
+		internal static KeyedRegistrationHelper GetInstance(IWindsorContainer container)
+		{
+			if (!_keyedRegistrations.TryGetValue(container, out var helper))
+			{
+				helper = new KeyedRegistrationHelper();
+				_keyedRegistrations.TryAdd(container, helper);
+			}
+
+			return helper;
+		}
+
+		internal const string KeyedRegistrationPrefix = "__KEYEDSERVICE__";
+
+		/// <summary>
+		/// Framework has special key KeyedService.AnyKey that is used to register a service with any key. This means that
+		/// whenever we are resolving a service with a key that is not registered, this can be used as fallback. So we 
+		/// need to explicitly know which services are registered with any key.
+		/// </summary>
+		private readonly ConcurrentDictionary<Type, KeyedRegistration> _typeRegisteredWithAnyKey = new();
+
+#if NET8_0_OR_GREATER
+
+		public string GetOrCreateKey(object key, ServiceDescriptor serviceDescriptor)
+		{
+			ArgumentNullException.ThrowIfNull(key);
+
+			var registrationKey = $"{KeyedRegistrationPrefix}+{Guid.NewGuid():X}";
+			var registration = CreateRegistration(key, serviceDescriptor, registrationKey);
+			if (!_keyToRegistrationMap.TryGetValue(key, out var registrations))
+			{
+				registrations = new List<KeyedRegistration>
+				{
+					registration
+				};
+				_keyToRegistrationMap.AddOrUpdate(key, registrations, (_, v) => { v.Add(registration); return v; });
+			}
+			else
+			{
+				//ok we already have the concurrent bag.
+				registrations.Add(registration);
+			}
+
+			//Now create an inverse map, where we have all registration done for a specific type.
+			if (!_typeToRegistrationMap.TryGetValue(serviceDescriptor.ServiceType, out var keyList))
+			{
+				keyList = new List<KeyedRegistration>
+				{
+					registration
+				};
+				_typeToRegistrationMap.AddOrUpdate(serviceDescriptor.ServiceType, keyList, (_, v) => { v.Add(registration); return v; });
+			}
+			else
+			{
+				keyList.Add(registration);
+			}
+
+			if (key == KeyedService.AnyKey)
+			{
+				var registered = _typeRegisteredWithAnyKey.TryAdd(serviceDescriptor.ServiceType, registration);
+				if (!registered)
+				{
+					throw new NotSupportedException("Cannot register more than one instance of the same service with the anykey.");
+				}
+			}
+
+			return registration.CastleRegistrationKey;
+		}
+
+		/// <summary>
+		/// There is a special attribute called ServiceKeyAttribute in the framework that require DI system to resolve
+		/// the service and pass the key object to that specific parameter. It seems an unnecessary feature but it
+		/// is tested by the standard test suite.
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="serviceDescriptor"></param>
+		/// <param name="registrationKey"></param>
+		/// <returns></returns>
+		private static KeyedRegistration CreateRegistration(object key, ServiceDescriptor serviceDescriptor, string registrationKey)
+		{
+			string serviceKeyParameterName = null;
+			if (serviceDescriptor.KeyedImplementationType != null)
+			{
+				var constructors = serviceDescriptor.KeyedImplementationType.GetConstructors();
+				foreach (var constructor in constructors)
+				{
+					var parameters = constructor.GetParameters();
+					foreach (var parameter in parameters)
+					{
+						if (parameter.GetCustomAttributes(typeof(ServiceKeyAttribute), true).Length != 0)
+						{
+							serviceKeyParameterName = parameter.Name;
+							break;
+						}
+					}
+				}
+			}
+
+			return new KeyedRegistration(key, serviceDescriptor, registrationKey, serviceKeyParameterName);
+		}
+
+		public KeyedRegistration GetKey(object key, Type serviceType)
+		{
+			ArgumentNullException.ThrowIfNull(key);
+			ArgumentNullException.ThrowIfNull(serviceType);
+
+			if (_keyToRegistrationMap.TryGetValue(key, out var registrations))
+			{
+				//ok we have services for this key.
+				var registration = registrations.FirstOrDefault(r => r.ServiceDescriptor.ServiceType == serviceType);
+				return registration;
+			}
+
+			//ok is it possible that this service was registered with any key?
+			if (_typeRegisteredWithAnyKey.TryGetValue(serviceType, out var registrationWithAnyKey))
+			{
+				//ok we really 
+				return registrationWithAnyKey;
+			}
+
+			return null;
+		}
+
+		public IEnumerable<KeyedRegistration> GetKeyedRegistrations(Type serviceType)
+		{
+			ArgumentNullException.ThrowIfNull(serviceType);
+
+			if (_typeToRegistrationMap.TryGetValue(serviceType, out var registrations))
+			{
+				return registrations;
+			}
+
+			return Array.Empty<KeyedRegistration>();
+		}
+
+		public bool HasKey(object key)
+		{
+			ArgumentNullException.ThrowIfNull(key);
+
+			return _keyToRegistrationMap.ContainsKey(key);
+		}
+#endif
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/KeyedRegistrationHelper.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/KeyedRegistrationHelper.cs
@@ -90,7 +90,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 		{
 			ArgumentNullException.ThrowIfNull(key);
 
-			var registrationKey = $"{KeyedRegistrationPrefix}+{Guid.NewGuid():X}";
+			var registrationKey = $"{KeyedRegistrationPrefix}+{Guid.NewGuid():N}";
 			var registration = CreateRegistration(key, serviceDescriptor, registrationKey);
 			if (!_keyToRegistrationMap.TryGetValue(key, out var registrations))
 			{

--- a/src/Castle.Windsor.Extensions.DependencyInjection/KeyedServicesSubDependencyResolver.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/KeyedServicesSubDependencyResolver.cs
@@ -1,0 +1,71 @@
+﻿#if NET8_0_OR_GREATER
+using Castle.Core;
+using Castle.MicroKernel;
+using Castle.MicroKernel.Context;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Castle.Windsor.Extensions.DependencyInjection
+{
+	internal class KeyedServicesSubDependencyResolver : ISubDependencyResolver
+	{
+		private readonly IWindsorContainer _container;
+
+		public KeyedServicesSubDependencyResolver(IWindsorContainer container)
+		{
+			_container = container;
+		}
+
+		/// <summary>
+		/// We cache in key all the factories that we have for specific constructor dependencies.
+		/// </summary>
+		private readonly Dictionary<string, Func<Object>> _factoriesCache = new();
+
+		public bool CanResolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency)
+		{
+			if (dependency is ConstructorDependencyModel cdm)
+			{
+				var cacheKey = GetFactoryCacheKey(cdm);
+				Func<Object> factory;
+				if (!_factoriesCache.TryGetValue(cacheKey, out factory))
+				{
+					//we are resolving a dependency of a constructor,where the parameter could be resolved by a keyed service
+					var constructorParameter = cdm.Constructor.Constructor.GetParameters().Single(p => p.Name == cdm.DependencyKey);
+					var attribute = constructorParameter.GetCustomAttribute<FromKeyedServicesAttribute>();
+					if (attribute != null)
+					{
+						var krh = KeyedRegistrationHelper.GetInstance(_container);
+						var registration = krh.GetKey(attribute.Key, cdm.TargetItemType);
+						//ok this parameter has an attribute, so we can cache
+						factory = () => registration.Resolve(_container);
+					}
+					_factoriesCache[cacheKey] = factory;
+				}
+
+				if (factory != null)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private static string GetFactoryCacheKey(ConstructorDependencyModel cdm)
+		{
+			return $"{cdm.TargetType.FullName}+{cdm.DependencyKey}";
+		}
+
+		public object Resolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency)
+		{
+			var cdm = (ConstructorDependencyModel)dependency;
+
+			var cacheKey = GetFactoryCacheKey(cdm);
+			var factory = _factoriesCache[cacheKey];
+			return factory();
+		}
+	}
+}
+#endif

--- a/src/Castle.Windsor.Extensions.DependencyInjection/PUBLISH_NUGET.md
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/PUBLISH_NUGET.md
@@ -1,0 +1,21 @@
+﻿# Build NuGet package
+
+- Update Castle.Windsor to the desired version.
+
+- Open a terminal.
+
+- Set the APPVEYOR_BUILD_VERSION environment variable to the version you want to publish:
+
+```bash
+set APPVEYOR_BUILD_VERSION=X.X.X-beta000X
+```
+
+- Launch the build script command:
+
+```bash
+build.cmd
+```
+
+- The NuGet package is generated in the `build` folder.
+
+- Remove the environment variable, it can cause issues when building in Visual Studio.

--- a/src/Castle.Windsor.Extensions.DependencyInjection/PUBLISH_NUGET.md
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/PUBLISH_NUGET.md
@@ -10,6 +10,10 @@
 set APPVEYOR_BUILD_VERSION=X.X.X-beta000X
 ```
 
+```powershell
+$env:APPVEYOR_BUILD_VERSION = "X.X.X-beta000X"
+```
+
 - Launch the build script command:
 
 ```bash

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -12,101 +12,123 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Windsor.Extensions.DependencyInjection {
-    using System;
+namespace Castle.Windsor.Extensions.DependencyInjection
+{
+	using System;
 
-    using Castle.MicroKernel.Registration;
-    using Castle.Windsor.Extensions.DependencyInjection.Extensions;
+	using Castle.MicroKernel.Registration;
+	using Castle.Windsor.Extensions.DependencyInjection.Extensions;
 
-    using Microsoft.Extensions.DependencyInjection;
+	using Microsoft.Extensions.DependencyInjection;
 
-    internal static class RegistrationAdapter {
-        public static IRegistration FromOpenGenericServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) {
-            ComponentRegistration<object> registration = Component.For(service.ServiceType)
-                .NamedAutomatically(UniqueComponentName(service));
+	internal static class RegistrationAdapter
+	{
+		public static IRegistration FromOpenGenericServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		{
+			ComponentRegistration<object> registration = Component.For(service.ServiceType)
+				.NamedAutomatically(UniqueComponentName(service));
 
-            if (service.ImplementationType != null) {
-                registration = UsingImplementation(registration, service);
-            }
-            else {
-                throw new System.ArgumentException("Unsupported ServiceDescriptor");
-            }
+			if (service.ImplementationType != null)
+			{
+				registration = UsingImplementation(registration, service);
+			}
+			else
+			{
+				throw new System.ArgumentException("Unsupported ServiceDescriptor");
+			}
 
-            return ResolveLifestyle(registration, service)
-                .IsDefault();
-        }
+			return ResolveLifestyle(registration, service)
+				.IsDefault();
+		}
 
-        public static IRegistration FromServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) {
-            var registration = Component.For(service.ServiceType)
-                .NamedAutomatically(UniqueComponentName(service));
+		public static IRegistration FromServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		{
+			var registration = Component.For(service.ServiceType)
+				.NamedAutomatically(UniqueComponentName(service));
 
-            if (service.ImplementationFactory != null) {
-                registration = UsingFactoryMethod(registration, service);
-            }
-            else if (service.ImplementationInstance != null) {
-                registration = UsingInstance(registration, service);
-            }
-            else if (service.ImplementationType != null) {
-                registration = UsingImplementation(registration, service);
-            }
+			if (service.ImplementationFactory != null)
+			{
+				registration = UsingFactoryMethod(registration, service);
+			}
+			else if (service.ImplementationInstance != null)
+			{
+				registration = UsingInstance(registration, service);
+			}
+			else if (service.ImplementationType != null)
+			{
+				registration = UsingImplementation(registration, service);
+			}
 
-            return ResolveLifestyle(registration, service)
-                .IsDefault();
-        }
+			return ResolveLifestyle(registration, service)
+				.IsDefault();
+		}
 
-        public static string OriginalComponentName(string uniqueComponentName) {
-            if (uniqueComponentName == null) {
-                return null;
-            }
-            if (!uniqueComponentName.Contains("@")) {
-                return uniqueComponentName;
-            }
-            return uniqueComponentName.Split('@')[0];
-        }
+		public static string OriginalComponentName(string uniqueComponentName)
+		{
+			if (uniqueComponentName == null)
+			{
+				return null;
+			}
+			if (!uniqueComponentName.Contains("@"))
+			{
+				return uniqueComponentName;
+			}
+			return uniqueComponentName.Split('@')[0];
+		}
 
-        internal static string UniqueComponentName(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) {
-            var result = "";
-            if (service.ImplementationType != null) {
-                result = service.ImplementationType.FullName;
-            }
-            else if (service.ImplementationInstance != null) {
-                result = service.ImplementationInstance.GetType().FullName;
-            }
-            else {
-                result = service.ImplementationFactory.GetType().FullName;
-            }
-            result = result + "@" + Guid.NewGuid().ToString();
+		internal static string UniqueComponentName(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		{
+			var result = "";
+			if (service.ImplementationType != null)
+			{
+				result = service.ImplementationType.FullName;
+			}
+			else if (service.ImplementationInstance != null)
+			{
+				result = service.ImplementationInstance.GetType().FullName;
+			}
+			else
+			{
+				result = service.ImplementationFactory.GetType().FullName;
+			}
+			result = result + "@" + Guid.NewGuid().ToString();
 
-            return result;
-        }
+			return result;
+		}
 
-        private static ComponentRegistration<TService> UsingFactoryMethod<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            return registration.UsingFactoryMethod((kernel) => {
-                var serviceProvider = kernel.Resolve<System.IServiceProvider>();
-                return service.ImplementationFactory(serviceProvider) as TService;
-            });
-        }
+		private static ComponentRegistration<TService> UsingFactoryMethod<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			return registration.UsingFactoryMethod((kernel) =>
+			{
+				var serviceProvider = kernel.Resolve<System.IServiceProvider>();
+				return service.ImplementationFactory(serviceProvider) as TService;
+			});
+		}
 
-        private static ComponentRegistration<TService> UsingInstance<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            return registration.Instance(service.ImplementationInstance as TService);
-        }
+		private static ComponentRegistration<TService> UsingInstance<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			return registration.Instance(service.ImplementationInstance as TService);
+		}
 
-        private static ComponentRegistration<TService> UsingImplementation<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            return registration.ImplementedBy(service.ImplementationType);
-        }
+		private static ComponentRegistration<TService> UsingImplementation<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			return registration.ImplementedBy(service.ImplementationType);
+		}
 
-        private static ComponentRegistration<TService> ResolveLifestyle<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class {
-            switch (service.Lifetime) {
-                case ServiceLifetime.Singleton:
-                    return registration.LifeStyle.NetStatic();
-                case ServiceLifetime.Scoped:
-                    return registration.LifeStyle.ScopedToNetServiceScope();
-                case ServiceLifetime.Transient:
-                    return registration.LifestyleNetTransient();
+		private static ComponentRegistration<TService> ResolveLifestyle<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		{
+			switch (service.Lifetime)
+			{
+				case ServiceLifetime.Singleton:
+					return registration.LifeStyle.NetStatic();
+				case ServiceLifetime.Scoped:
+					return registration.LifeStyle.ScopedToNetServiceScope();
+				case ServiceLifetime.Transient:
+					return registration.LifestyleNetTransient();
 
-                default:
-                    throw new System.ArgumentException($"Invalid lifetime {service.Lifetime}");
-            }
-        }
-    }
+				default:
+					throw new System.ArgumentException($"Invalid lifetime {service.Lifetime}");
+			}
+		}
+	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -14,20 +14,49 @@
 
 namespace Castle.Windsor.Extensions.DependencyInjection
 {
-	using System;
-
 	using Castle.MicroKernel.Registration;
 	using Castle.Windsor.Extensions.DependencyInjection.Extensions;
-
 	using Microsoft.Extensions.DependencyInjection;
+	using System;
 
 	internal static class RegistrationAdapter
 	{
-		public static IRegistration FromOpenGenericServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		public static IRegistration FromOpenGenericServiceDescriptor(
+			Microsoft.Extensions.DependencyInjection.ServiceDescriptor service,
+			IWindsorContainer windsorContainer)
 		{
-			ComponentRegistration<object> registration = Component.For(service.ServiceType)
-				.NamedAutomatically(UniqueComponentName(service));
+			ComponentRegistration<object> registration;
 
+#if NET8_0_OR_GREATER
+			if (service.IsKeyedService)
+			{
+				registration = Component.For(service.ServiceType)
+					.Named(KeyedRegistrationHelper.GetInstance(windsorContainer).GetOrCreateKey(service.ServiceKey, service));
+				if (service.KeyedImplementationType != null)
+				{
+					registration = UsingImplementation(registration, service);
+				}
+				else
+				{
+					throw new System.ArgumentException("Unsupported ServiceDescriptor");
+				}
+			}
+			else
+			{
+				registration = Component.For(service.ServiceType)
+					.NamedAutomatically(UniqueComponentName(service));
+				if (service.ImplementationType != null)
+				{
+					registration = UsingImplementation(registration, service);
+				}
+				else
+				{
+					throw new System.ArgumentException("Unsupported ServiceDescriptor");
+				}
+			}
+#else
+			registration = Component.For(service.ServiceType)
+				.NamedAutomatically(UniqueComponentName(service));
 			if (service.ImplementationType != null)
 			{
 				registration = UsingImplementation(registration, service);
@@ -36,16 +65,55 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 			{
 				throw new System.ArgumentException("Unsupported ServiceDescriptor");
 			}
-
+#endif
 			return ResolveLifestyle(registration, service)
 				.IsDefault();
 		}
 
-		public static IRegistration FromServiceDescriptor(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
+		public static IRegistration FromServiceDescriptor(
+			Microsoft.Extensions.DependencyInjection.ServiceDescriptor service,
+			IWindsorContainer windsorContainer)
 		{
-			var registration = Component.For(service.ServiceType)
-				.NamedAutomatically(UniqueComponentName(service));
+			ComponentRegistration<object> registration;
+#if NET8_0_OR_GREATER
+			if (service.IsKeyedService)
+			{
+				registration = Component.For(service.ServiceType)
+					.Named(KeyedRegistrationHelper.GetInstance(windsorContainer).GetOrCreateKey(service.ServiceKey, service));
 
+				if (service.KeyedImplementationFactory != null)
+				{
+					registration = UsingFactoryMethod(registration, service);
+				}
+				else if (service.KeyedImplementationInstance != null)
+				{
+					registration = UsingInstance(registration, service);
+				}
+				else if (service.KeyedImplementationType != null)
+				{
+					registration = UsingImplementation(registration, service);
+				}
+			}
+			else
+			{
+				registration = Component.For(service.ServiceType)
+					.NamedAutomatically(UniqueComponentName(service));
+				if (service.ImplementationFactory != null)
+				{
+					registration = UsingFactoryMethod(registration, service);
+				}
+				else if (service.ImplementationInstance != null)
+				{
+					registration = UsingInstance(registration, service);
+				}
+				else if (service.ImplementationType != null)
+				{
+					registration = UsingImplementation(registration, service);
+				}
+			}
+#else
+			registration = Component.For(service.ServiceType)
+				.NamedAutomatically(UniqueComponentName(service));
 			if (service.ImplementationFactory != null)
 			{
 				registration = UsingFactoryMethod(registration, service);
@@ -58,7 +126,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 			{
 				registration = UsingImplementation(registration, service);
 			}
-
+#endif
 			return ResolveLifestyle(registration, service)
 				.IsDefault();
 		}
@@ -79,7 +147,39 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 		internal static string UniqueComponentName(Microsoft.Extensions.DependencyInjection.ServiceDescriptor service)
 		{
 			var result = "";
-			if (service.ImplementationType != null)
+#if NET8_0_OR_GREATER
+			if (service.IsKeyedService)
+			{
+				if (service.KeyedImplementationType != null)
+				{
+					result = service.KeyedImplementationType.FullName;
+				}
+				else if (service.KeyedImplementationInstance != null)
+				{
+					result = service.KeyedImplementationInstance.GetType().FullName;
+				}
+				else
+				{
+					result = service.KeyedImplementationFactory.GetType().FullName;
+				}
+			}
+			else
+			{
+				if (service.ImplementationType != null)
+				{
+					result = service.ImplementationType.FullName;
+				}
+				else if (service.ImplementationInstance != null)
+				{
+					result = service.ImplementationInstance.GetType().FullName;
+				}
+				else
+				{
+					result = service.ImplementationFactory.GetType().FullName;
+				}
+			}
+#else
+if (service.ImplementationType != null)
 			{
 				result = service.ImplementationType.FullName;
 			}
@@ -91,28 +191,68 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 			{
 				result = service.ImplementationFactory.GetType().FullName;
 			}
+
+			
+#endif
 			result = result + "@" + Guid.NewGuid().ToString();
 
 			return result;
 		}
 
-		private static ComponentRegistration<TService> UsingFactoryMethod<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
+		private static ComponentRegistration<TService> UsingFactoryMethod<TService>(
+			ComponentRegistration<TService> registration,
+			Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
 		{
 			return registration.UsingFactoryMethod((kernel) =>
 			{
+				//TODO: We should register a factory in castle that in turns call the implementation factory??
 				var serviceProvider = kernel.Resolve<System.IServiceProvider>();
+#if NET8_0_OR_GREATER
+				if (service.IsKeyedService)
+				{
+					return service.KeyedImplementationFactory(serviceProvider, service.ServiceKey) as TService;
+				}
+				else
+				{
+					return service.ImplementationFactory(serviceProvider) as TService;
+				}
+#else
 				return service.ImplementationFactory(serviceProvider) as TService;
+				
+#endif
 			});
 		}
 
 		private static ComponentRegistration<TService> UsingInstance<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
 		{
+#if NET8_0_OR_GREATER
+			if (service.IsKeyedService)
+			{
+				return registration.Instance(service.KeyedImplementationInstance as TService);
+			}
+			else
+			{
+				return registration.Instance(service.ImplementationInstance as TService);
+			}
+#else
 			return registration.Instance(service.ImplementationInstance as TService);
+#endif
 		}
 
 		private static ComponentRegistration<TService> UsingImplementation<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class
 		{
+#if NET8_0_OR_GREATER
+			if (service.IsKeyedService)
+			{
+				return registration.ImplementedBy(service.KeyedImplementationType);
+			}
+			else
+			{
+				return registration.ImplementedBy(service.ImplementationType);
+			}
+#else
 			return registration.ImplementedBy(service.ImplementationType);
+#endif
 		}
 
 		private static ComponentRegistration<TService> ResolveLifestyle<TService>(ComponentRegistration<TService> registration, Microsoft.Extensions.DependencyInjection.ServiceDescriptor service) where TService : class

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -66,8 +66,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 				throw new System.ArgumentException("Unsupported ServiceDescriptor");
 			}
 #endif
-			return ResolveLifestyle(registration, service)
-				.IsDefault();
+			return ResolveLifestyle(registration, service);
 		}
 
 		public static IRegistration FromServiceDescriptor(
@@ -127,8 +126,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 				registration = UsingImplementation(registration, service);
 			}
 #endif
-			return ResolveLifestyle(registration, service)
-				.IsDefault();
+			return ResolveLifestyle(registration, service);
 		}
 
 		public static string OriginalComponentName(string uniqueComponentName)

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -21,6 +21,13 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 	internal static class RegistrationAdapter
 	{
+		/// <summary>
+		/// This is a constants that is used as key in the extended properties of a component
+		/// when it is registered through RegistrationAdapter. This allows to understand which
+		/// is the best semantic to use when resolving the component.
+		/// </summary>
+		internal static string RegistrationKeyExtendedPropertyKey = "microsoft-di-registered";
+
 		public static IRegistration FromOpenGenericServiceDescriptor(
 			Microsoft.Extensions.DependencyInjection.ServiceDescriptor service,
 			IWindsorContainer windsorContainer)
@@ -66,7 +73,11 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 				throw new System.ArgumentException("Unsupported ServiceDescriptor");
 			}
 #endif
-			return ResolveLifestyle(registration, service);
+			//Extended properties allows to understand when the service was registered through the adapter
+			//and IsDefault is needed to change the semantic of the resolution, LAST registered service win.
+			return ResolveLifestyle(registration, service)
+				.ExtendedProperties(RegistrationKeyExtendedPropertyKey)
+				.IsDefault();
 		}
 
 		public static IRegistration FromServiceDescriptor(
@@ -126,7 +137,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 				registration = UsingImplementation(registration, service);
 			}
 #endif
-			return ResolveLifestyle(registration, service);
+			return ResolveLifestyle(registration, service)
+				.ExtendedProperties(RegistrationKeyExtendedPropertyKey)
+				.IsDefault();
 		}
 
 		public static string OriginalComponentName(string uniqueComponentName)

--- a/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/RegistrationAdapter.cs
@@ -216,7 +216,6 @@ if (service.ImplementationType != null)
 		{
 			return registration.UsingFactoryMethod((kernel) =>
 			{
-				//TODO: We should register a factory in castle that in turns call the implementation factory??
 				var serviceProvider = kernel.Resolve<System.IServiceProvider>();
 #if NET8_0_OR_GREATER
 				if (service.IsKeyedService)
@@ -229,7 +228,6 @@ if (service.ImplementationType != null)
 				}
 #else
 				return service.ImplementationFactory(serviceProvider) as TService;
-				
 #endif
 			});
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Resolvers/LoggerDependencyResolver.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Resolvers/LoggerDependencyResolver.cs
@@ -18,7 +18,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Resolvers
 	using Castle.Core;
 	using Castle.MicroKernel;
 	using Castle.MicroKernel.Context;
-	
+
 	using Microsoft.Extensions.Logging;
 
 	public class LoggerDependencyResolver : ISubDependencyResolver

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScope.cs
@@ -16,7 +16,6 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	internal class ExtensionContainerRootScope : ExtensionContainerScopeBase
 	{
-		
 		public static ExtensionContainerRootScope BeginRootScope()
 		{
 			var scope = new ExtensionContainerRootScope();

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -12,24 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
+namespace Castle.Windsor.Extensions.DependencyInjection.Scope
+{
 	using System;
 
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
 
-	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor {
-		public ILifetimeScope GetScope(CreationContext context) {
-			/*
-			if (ExtensionContainerScopeCache.Current == null) {
-				// might be null in threads spawn from Threadpool.UnsafeQueueUserWorkItem
-				return null;
-			}
-			*/
+	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor
+	{
+		public ILifetimeScope GetScope(CreationContext context)
+		{
 			return ExtensionContainerScopeCache.Current?.RootScope ?? throw new InvalidOperationException("No root scope available.");
 		}
 
-		public void Dispose() {
+		public void Dispose()
+		{
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -26,7 +26,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 				return null;
 			}
 			*/
-			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
+			return ExtensionContainerScopeCache.Current?.RootScope ?? throw new InvalidOperationException("No root scope available.");
 		}
 
 		public void Dispose() {

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -20,10 +20,12 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 
 	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor {
 		public ILifetimeScope GetScope(CreationContext context) {
+			/*
 			if (ExtensionContainerScopeCache.Current == null) {
 				// might be null in threads spawn from Threadpool.UnsafeQueueUserWorkItem
 				return null;
 			}
+			*/
 			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
 		}
 

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -15,7 +15,7 @@
 namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	using System;
-
+	using Castle.Core.Logging;
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
 
@@ -23,7 +23,24 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 	{
 		public ILifetimeScope GetScope(CreationContext context)
 		{
-			return ExtensionContainerScopeCache.Current?.RootScope ?? throw new InvalidOperationException("No root scope available.");
+			if (ExtensionContainerScopeCache.Current?.RootScope == null)
+			{
+				//TODO: if we have a way from context to retrieve the instance of container/kernel we could use it to get
+				//a reference of the correct root scope with a call to WindsorServiceProviderFactoryBase.GetSingleRootScope
+				//but since in this version we cannot determine the container from this context. 
+
+				//In this version we have the limit to have only one container registered in the dependency injection chain of
+				//.NET core, so we call a different method that gives us the single root scope.				
+				var scope = WindsorServiceProviderFactoryBase.GetSingleRootScope();
+
+				if (scope == null)
+				{
+					throw new InvalidOperationException($"{nameof(ExtensionContainerRootScopeAccessor)}: We are trying to access a ROOT scope null for requested type {context.RequestedType}");
+				}
+
+				return scope;
+			}
+			return ExtensionContainerScopeCache.Current?.RootScope;
 		}
 
 		public void Dispose()

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -14,10 +14,9 @@
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
-	using System;
-	using Castle.Core.Logging;
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
+	using System;
 
 	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor
 	{
@@ -25,17 +24,11 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		{
 			if (ExtensionContainerScopeCache.Current?.RootScope == null)
 			{
-				//TODO: if we have a way from context to retrieve the instance of container/kernel we could use it to get
-				//a reference of the correct root scope with a call to WindsorServiceProviderFactoryBase.GetSingleRootScope
-				//but since in this version we cannot determine the container from this context. 
-
-				//In this version we have the limit to have only one container registered in the dependency injection chain of
-				//.NET core, so we call a different method that gives us the single root scope.				
-				var scope = WindsorServiceProviderFactoryBase.GetSingleRootScope();
+				var scope = WindsorServiceProviderFactoryBase.GetRootScopeForKernel(context.Handler.GetKernel());
 
 				if (scope == null)
 				{
-					throw new InvalidOperationException($"{nameof(ExtensionContainerRootScopeAccessor)}: We are trying to access a ROOT scope null for requested type {context.RequestedType}");
+					throw new InvalidOperationException($"{nameof(ExtensionContainerRootScopeAccessor)}: We are trying to access a ROOT scope null for requested type {context.RequestedType} current kernel is not associated with any root scope");
 				}
 
 				return scope;

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerRootScopeAccessor.cs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.Windsor.Extensions.DependencyInjection.Scope
-{
+namespace Castle.Windsor.Extensions.DependencyInjection.Scope {
 	using System;
 
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
 
-	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor
-	{
-		public ILifetimeScope GetScope(CreationContext context)
-		{
+	internal class ExtensionContainerRootScopeAccessor : IScopeAccessor {
+		public ILifetimeScope GetScope(CreationContext context) {
+			if (ExtensionContainerScopeCache.Current == null) {
+				// might be null in threads spawn from Threadpool.UnsafeQueueUserWorkItem
+				return null;
+			}
 			return ExtensionContainerScopeCache.Current.RootScope ?? throw new InvalidOperationException("No root scope available");
 		}
 
-		public void Dispose()
-		{
+		public void Dispose() {
 		}
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	internal class ExtensionContainerScope : ExtensionContainerScopeBase
@@ -27,7 +29,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 
 		internal static ExtensionContainerScopeBase BeginScope()
 		{
-			var scope = new ExtensionContainerScope { RootScope = ExtensionContainerScopeCache.Current?.RootScope };
+			var scope = new ExtensionContainerScope();
+			scope.RootScope = ExtensionContainerScopeCache.Current?.RootScope;
 			ExtensionContainerScopeCache.Current = scope;
 			return scope;
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
@@ -25,10 +25,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 
 		internal override ExtensionContainerScopeBase RootScope { get; set; }
 
-
 		internal static ExtensionContainerScopeBase BeginScope()
 		{
-			var scope = new ExtensionContainerScope { RootScope = ExtensionContainerScopeCache.Current.RootScope };
+			var scope = new ExtensionContainerScope { RootScope = ExtensionContainerScopeCache.Current?.RootScope };
 			ExtensionContainerScopeCache.Current = scope;
 			return scope;
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	internal class ExtensionContainerScope : ExtensionContainerScopeBase

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeAccessor.cs
@@ -22,7 +22,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 	{
 		public ILifetimeScope GetScope(CreationContext context)
 		{
-			return ExtensionContainerScopeCache.Current ?? throw new InvalidOperationException("No scope available. Did you forget to call IServiceScopeFactory.CreateScope()?"); ;
+			return ExtensionContainerScopeCache.Current;
 		}
 
 		public void Dispose()

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeAccessor.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeAccessor.cs
@@ -16,12 +16,13 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	using Castle.MicroKernel.Context;
 	using Castle.MicroKernel.Lifestyle.Scoped;
+	using System;
 
 	internal class ExtensionContainerScopeAccessor : IScopeAccessor
 	{
 		public ILifetimeScope GetScope(CreationContext context)
 		{
-			return ExtensionContainerScopeCache.Current;
+			return ExtensionContainerScopeCache.Current ?? throw new InvalidOperationException("No scope available. Did you forget to call IServiceScopeFactory.CreateScope()?"); ;
 		}
 
 		public void Dispose()

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeBase.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeBase.cs
@@ -25,14 +25,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		public static readonly string TransientMarker = "Transient";
 		private readonly IScopeCache scopeCache;
 
-		private static long _counter;
-
-		public long Counter { get; private set; }
-
 		protected ExtensionContainerScopeBase()
 		{
 			scopeCache = new ScopeCache();
-			Counter = Interlocked.Increment(ref _counter);
 		}
 
 		internal virtual ExtensionContainerScopeBase RootScope { get; set; }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeBase.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeBase.cs
@@ -15,7 +15,7 @@
 namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	using System;
-	
+	using System.Threading;
 	using Castle.Core;
 	using Castle.MicroKernel;
 	using Castle.MicroKernel.Lifestyle.Scoped;
@@ -25,9 +25,14 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		public static readonly string TransientMarker = "Transient";
 		private readonly IScopeCache scopeCache;
 
+		private static long _counter;
+
+		public long Counter { get; private set; }
+
 		protected ExtensionContainerScopeBase()
 		{
 			scopeCache = new ScopeCache();
+			Counter = Interlocked.Increment(ref _counter);
 		}
 
 		internal virtual ExtensionContainerScopeBase RootScope { get; set; }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value ?? throw new InvalidOperationException("No scope available");
+			get => current.Value; // ?? throw new InvalidOperationException("No scope available");
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -20,6 +20,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 	internal static class ExtensionContainerScopeCache
 	{
 		internal static readonly AsyncLocal<ExtensionContainerScopeBase> current = new AsyncLocal<ExtensionContainerScopeBase>();
+
 		/// <summary>Current scope for the thread. Initial scope will be set when calling BeginRootScope from a ExtensionContainerRootScope instance.</summary>
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value ?? throw new InvalidOperationException("No scope available"); // originally there was no exception
+			// AysncLocal can be null in some cases (like Threadpool.UnsafeQueueUserWorkItem)
+			get => current.Value; // ?? throw new InvalidOperationException("No scope available. Did you forget to call IServiceScopeFactory.CreateScope()?");
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -24,7 +24,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
 		{
-			get => current.Value; // ?? throw new InvalidOperationException("No scope available");
+			get => current.Value ?? throw new InvalidOperationException("No scope available"); // originally there was no exception
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -26,7 +26,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		internal static ExtensionContainerScopeBase Current
 		{
 			// AysncLocal can be null in some cases (like Threadpool.UnsafeQueueUserWorkItem)
-			get => current.Value; // ?? throw new InvalidOperationException("No scope available. Did you forget to call IServiceScopeFactory.CreateScope()?");
+			get => current.Value;
 			set => current.Value = value;
 		}
 	}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/WindsorScopeFactory.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/WindsorScopeFactory.cs
@@ -15,16 +15,14 @@
 
 namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
-	using System;
-
 	using Castle.Windsor;
-
 	using Microsoft.Extensions.DependencyInjection;
+	using System;
 
 	internal class WindsorScopeFactory : IServiceScopeFactory
 	{
 		private readonly IWindsorContainer scopeFactoryContainer;
-		
+
 		public WindsorScopeFactory(IWindsorContainer container)
 		{
 			scopeFactoryContainer = container;
@@ -34,8 +32,8 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 		{
 			var scope = ExtensionContainerScope.BeginScope();
 
-			//since WindsorServiceProvider is scoped, this gives us new instance
-			var provider = scopeFactoryContainer.Resolve<IServiceProvider>();
+			//Tests in .NET makes sure that we have a differente scoped service provider for each scope.
+			var provider = new WindsorScopedServiceProvider(scopeFactoryContainer);
 
 			return new ServiceScope(scope, provider);
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/WindsorScopeFactory.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/WindsorScopeFactory.cs
@@ -17,7 +17,6 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 {
 	using Castle.Windsor;
 	using Microsoft.Extensions.DependencyInjection;
-	using System;
 
 	internal class WindsorScopeFactory : IServiceScopeFactory
 	{

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorDependencyInjectionOptions.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorDependencyInjectionOptions.cs
@@ -1,0 +1,16 @@
+﻿namespace Castle.Windsor.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// Global settins to change the dependency injection behavior.
+	/// These settings should be set before the container is created.
+	/// </summary>
+	public static class WindsorDependencyInjectionOptions
+	{
+		/// <summary>
+		/// Map NetStatic lifestyle to Castle Windsor Singleton lifestyle.
+		/// The whole RootScope handling is disabled.
+		/// (defaut: false)
+		/// </summary>
+		public static bool MapNetStaticToSingleton { get; set; }
+	}
+}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
@@ -12,19 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 namespace Castle.Windsor.Extensions.DependencyInjection
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Reflection;
-
+	using Castle.MicroKernel.Handlers;
 	using Castle.Windsor;
 	using Castle.Windsor.Extensions.DependencyInjection.Scope;
-
 	using Microsoft.Extensions.DependencyInjection;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Reflection;
 
 	internal class WindsorScopedServiceProvider : IServiceProvider, ISupportRequiredService, IDisposable
+#if NET6_0_OR_GREATER
+	, IServiceProviderIsService
+#endif
+#if NET8_0_OR_GREATER
+		, IKeyedServiceProvider, IServiceProviderIsKeyedService
+#endif
 	{
 		private readonly ExtensionContainerScopeBase scope;
 		private bool disposing;
@@ -44,6 +49,26 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 				return ResolveInstanceOrNull(serviceType, true);
 			}
 		}
+
+#if NET8_0_OR_GREATER
+
+		public object GetKeyedService(Type serviceType, object serviceKey)
+		{
+			using (_ = new ForcedScope(scope))
+			{
+				return ResolveInstanceOrNull(serviceType, serviceKey, true);
+			}
+		}
+
+		public object GetRequiredKeyedService(Type serviceType, object serviceKey)
+		{
+			using (_ = new ForcedScope(scope))
+			{
+				return ResolveInstanceOrNull(serviceType, serviceKey, false);
+			}
+		}
+
+#endif
 
 		public object GetRequiredService(Type serviceType)
 		{
@@ -65,17 +90,64 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 			// disping the container here is questionable... what if I want to create another IServiceProvider form the factory?
 			container.Dispose();
 		}
+
 		private object ResolveInstanceOrNull(Type serviceType, bool isOptional)
 		{
 			if (container.Kernel.HasComponent(serviceType))
 			{
+#if NET8_0_OR_GREATER
+				//this is complicated by the concept of keyed service, because if you are about to resolve WITHOUTH KEY you do not
+				//need to resolve keyed services. Now Keyed services are available only in version 8 but we register with an helper
+				//all registered services so we can know if a service was really registered with keyed service or not.
+				var componentRegistration = container.Kernel.GetHandler(serviceType);
+				if (componentRegistration.ComponentModel.Name.StartsWith(KeyedRegistrationHelper.KeyedRegistrationPrefix))
+				{
+					//Component was registered as keyed component, so we really need to resolve with null because this is the old interface
+					//so no key is provided.
+					return null;
+				}
+#endif
 				return container.Resolve(serviceType);
 			}
 
 			if (serviceType.GetTypeInfo().IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
 			{
-				var allObjects = container.ResolveAll(serviceType.GenericTypeArguments[0]);
-				return allObjects;
+				//ok we want to resolve all references, NON keyed services
+				var typeToResolve = serviceType.GenericTypeArguments[0];
+				var allRegisteredTypes = container.Kernel.GetHandlers(typeToResolve);
+				var allNonKeyedService = allRegisteredTypes.Where(x => !x.ComponentModel.Name.StartsWith(KeyedRegistrationHelper.KeyedRegistrationPrefix)).ToList();
+				//now we need to resolve one by one all these services
+				var listType = typeof(List<>).MakeGenericType(typeToResolve);
+				var objects = (System.Collections.IList)Activator.CreateInstance(listType);
+
+				if (allNonKeyedService.Count == 0)
+				{
+					return objects;
+				}
+				else if (allNonKeyedService.Count == allRegisteredTypes.Length)
+				{
+					//simply resolve all
+					return container.ResolveAll(typeToResolve);
+				}
+
+				//if we reach here some of the services are kyed and some are not, so we need to resolve one by one.
+				for (int i = 0; i < allNonKeyedService.Count; i++)
+				{
+					var service = allNonKeyedService[i];
+					object obj;
+					//type is non generic, we can directly resolve.
+					try
+					{
+						obj = container.Resolve(allNonKeyedService[i].ComponentModel.Name, typeToResolve);
+						objects.Add(obj);
+					}
+					catch (GenericHandlerTypeMismatchException)
+					{
+						//ignore, this is the standard way we know that we cannot instantiate an open generic with a given type.
+					}
+				}
+
+				return objects;
 			}
 
 			if (isOptional)
@@ -85,5 +157,94 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 			return container.Resolve(serviceType);
 		}
+
+#if NET6_0_OR_GREATER
+
+		public bool IsService(Type serviceType)
+		{
+			if (serviceType.IsGenericTypeDefinition)
+			{
+				//Framework does not want the open definition to return true
+				return false;
+			}
+
+			//IEnumerable always return true
+			if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+			{
+				var enumerableType = serviceType.GenericTypeArguments[0];
+				if (container.Kernel.HasComponent(enumerableType))
+				{
+					return true;
+				}
+				//Try to check if the real type is registered: framework test IEnumerableWithIsServiceAlwaysReturnsTrue1
+				var interfaces = enumerableType.GetInterfaces();
+				return interfaces.Any(container.Kernel.HasComponent);
+			}
+			return container.Kernel.HasComponent(serviceType);
+		}
+
+#endif
+
+#if NET8_0_OR_GREATER
+
+		private object ResolveInstanceOrNull(Type serviceType, object serviceKey, bool isOptional)
+		{
+			if (serviceKey == null)
+			{
+				return ResolveInstanceOrNull(serviceType, isOptional);
+			}
+
+			KeyedRegistrationHelper keyedRegistrationHelper = KeyedRegistrationHelper.GetInstance(container);
+
+			if (container.Kernel.HasComponent(serviceType))
+			{
+				var keyRegistrationHelper = keyedRegistrationHelper.GetKey(serviceKey, serviceType);
+				//this is a keyed service, actually we need to grab the name from the service key
+				if (keyRegistrationHelper != null)
+				{
+					return keyRegistrationHelper.Resolve(container, serviceKey);
+				}
+			}
+
+			if (serviceType.GetTypeInfo().IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+			{
+				var typeToResolve = serviceType.GenericTypeArguments[0];
+				var registrations = keyedRegistrationHelper.GetKeyedRegistrations(typeToResolve);
+				var regisrationsWithKey = registrations.Where(x => x.Key == serviceKey).ToList();
+
+				if (regisrationsWithKey.Count > 0)
+				{
+					var listType = typeof(List<>).MakeGenericType(typeToResolve);
+					var objects = (System.Collections.IList)Activator.CreateInstance(listType);
+					foreach (var registration in regisrationsWithKey)
+					{
+						var obj = registration.Resolve(container, serviceKey);
+						objects.Add(obj);
+					}
+					return objects;
+				}
+			}
+
+			if (isOptional)
+			{
+				return null;
+			}
+
+			return container.Resolve(serviceType);
+		}
+
+		public bool IsKeyedService(Type serviceType, object serviceKey)
+		{
+			//we just need to know if the key is registered.
+			if (serviceKey == null)
+			{
+				//test NonKeyedServiceWithIsKeyedService shows that for real inversion of control when sercvice key is null
+				//it just mean that we need to know if the service is registered.
+				return IsService(serviceType);
+			}
+			return KeyedRegistrationHelper.GetInstance(container).HasKey(serviceKey);
+		}
+
+#endif
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
@@ -18,7 +18,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 	using System;
 	using System.Collections.Generic;
 	using System.Reflection;
-	
+
 	using Castle.Windsor;
 	using Castle.Windsor.Extensions.DependencyInjection.Scope;
 
@@ -30,7 +30,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 		private bool disposing;
 
 		private readonly IWindsorContainer container;
-		
+
 		public WindsorScopedServiceProvider(IWindsorContainer container)
 		{
 			this.container = container;
@@ -39,27 +39,30 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 		public object GetService(Type serviceType)
 		{
-			using(_ = new ForcedScope(scope))
+			using (_ = new ForcedScope(scope))
 			{
-				return ResolveInstanceOrNull(serviceType, true);	
+				return ResolveInstanceOrNull(serviceType, true);
 			}
 		}
 
 		public object GetRequiredService(Type serviceType)
 		{
-			using(_ = new ForcedScope(scope))
+			using (_ = new ForcedScope(scope))
 			{
-				return ResolveInstanceOrNull(serviceType, false);	
+				return ResolveInstanceOrNull(serviceType, false);
 			}
 		}
 
 		public void Dispose()
 		{
+			// root scope should be tied to the root IserviceProvider, so
+			// it has to be disposed with the IserviceProvider to which is tied to
 			if (!(scope is ExtensionContainerRootScope)) return;
 			if (disposing) return;
 			disposing = true;
 			var disposableScope = scope as IDisposable;
 			disposableScope?.Dispose();
+			// disping the container here is questionable... what if I want to create another IServiceProvider form the factory?
 			container.Dispose();
 		}
 		private object ResolveInstanceOrNull(Type serviceType, bool isOptional)

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
@@ -94,7 +94,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 			var disposableScope = scope as IDisposable;
 			disposableScope?.Dispose();
 			// disping the container here is questionable... what if I want to create another IServiceProvider form the factory?
-			container.Dispose();
+			// we have also another consideration. When we use orleans we find that orleans dispose the Scoped service provider and
+			// since we have a single container, we cannot dispose here. The global container must be disposed from external code.
+			// container.Dispose();
 		}
 
 		private object ResolveInstanceOrNull(Type serviceType, bool isOptional)

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorServiceProviderFactory.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorServiceProviderFactory.cs
@@ -18,7 +18,6 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 	public sealed class WindsorServiceProviderFactory : WindsorServiceProviderFactoryBase
 	{
-
 		public WindsorServiceProviderFactory()
 		{
 			CreateRootScope();

--- a/src/Castle.Windsor.Extensions.Hosting/Castle.Windsor.Extensions.Hosting.csproj
+++ b/src/Castle.Windsor.Extensions.Hosting/Castle.Windsor.Extensions.Hosting.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Windsor.Extensions.Hosting/Castle.Windsor.Extensions.Hosting.csproj
+++ b/src/Castle.Windsor.Extensions.Hosting/Castle.Windsor.Extensions.Hosting.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -47,7 +47,7 @@
 		<PackageReference Include="Castle.Core-log4net" Version="[5.1.0,6.0)" />
 		<PackageReference Include="Castle.Core-NLog" Version="[5.1.0,6.0)" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
+++ b/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
@@ -138,10 +138,7 @@ namespace Castle.MicroKernel.ComponentActivator
 		protected object CreateInstanceCore(ConstructorCandidate constructor, object[] arguments, Type implType)
 		{
 			object instance;
-			if (Model.Implementation.FullName.Contains("SiloConnectionFactory")) 
-			{
-			
-			}
+
 			try
 			{
 #if FEATURE_REMOTING

--- a/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
+++ b/src/Castle.Windsor/MicroKernel/ComponentActivator/DefaultComponentActivator.cs
@@ -138,6 +138,10 @@ namespace Castle.MicroKernel.ComponentActivator
 		protected object CreateInstanceCore(ConstructorCandidate constructor, object[] arguments, Type implType)
 		{
 			object instance;
+			if (Model.Implementation.FullName.Contains("SiloConnectionFactory")) 
+			{
+			
+			}
 			try
 			{
 #if FEATURE_REMOTING

--- a/src/Castle.Windsor/MicroKernel/DefaultKernel.cs
+++ b/src/Castle.Windsor/MicroKernel/DefaultKernel.cs
@@ -694,9 +694,10 @@ namespace Castle.MicroKernel
 			return new CreationContext(handler, policy, requestedType, additionalArguments, ConversionSubSystem, parent);
 		}
 
-		/// <remarks>
-		///   It is the responsibility of the kernel to ensure that handler is only ever disposed once.
-		/// </remarks>
+		/// <summary>
+		///  It is the responsibility of the kernel to ensure that handler is only ever disposed once.
+		/// </summary>
+		/// <param name="handler"></param>
 		protected void DisposeHandler(IHandler handler)
 		{
 			var disposable = handler as IDisposable;

--- a/src/Castle.Windsor/MicroKernel/Handlers/AbstractHandler.cs
+++ b/src/Castle.Windsor/MicroKernel/Handlers/AbstractHandler.cs
@@ -126,6 +126,11 @@ namespace Castle.MicroKernel.Handlers
 			return model.CustomDependencies.Contains(key);
 		}
 
+		IKernel IHandler.GetKernel()
+		{
+			return kernel;
+		}
+
 		/// <summary>
 		///   Saves the kernel instance, subscribes to <see cref = "IKernelEvents.AddedAsChildKernel" /> event, creates the lifestyle manager instance and computes the handler state.
 		/// </summary>

--- a/src/Castle.Windsor/MicroKernel/Handlers/DefaultGenericHandler.cs
+++ b/src/Castle.Windsor/MicroKernel/Handlers/DefaultGenericHandler.cs
@@ -361,7 +361,7 @@ namespace Castle.MicroKernel.Handlers
 					throw new HandlerException(message, ComponentModel.ComponentName, e);
 				}
 				// 3. at this point we should be 99% sure we have arguments that don't satisfy generic constraints of out service.
-				throw new GenericHandlerTypeMismatchException(genericArguments, ComponentModel, this);
+				throw new GenericHandlerTypeMismatchException(genericArguments, ComponentModel, this, e);
 			}
 		}
 

--- a/src/Castle.Windsor/MicroKernel/Handlers/GenericHandlerTypeMismatchException.cs
+++ b/src/Castle.Windsor/MicroKernel/Handlers/GenericHandlerTypeMismatchException.cs
@@ -47,8 +47,8 @@ namespace Castle.MicroKernel.Handlers
 		{
 		}
 
-		public GenericHandlerTypeMismatchException(IEnumerable<Type> argumentsUsed, ComponentModel componentModel, DefaultGenericHandler handler)
-			: base(BuildMessage(argumentsUsed.Select(a => a.FullName).ToArray(), componentModel, handler), componentModel.ComponentName)
+		public GenericHandlerTypeMismatchException(IEnumerable<Type> argumentsUsed, ComponentModel componentModel, DefaultGenericHandler handler, Exception innerException)
+			: base(BuildMessage(argumentsUsed.Select(a => a.FullName).ToArray(), componentModel, handler), componentModel.ComponentName, innerException)
 		{
 		}
 

--- a/src/Castle.Windsor/MicroKernel/Handlers/ParentHandlerWrapper.cs
+++ b/src/Castle.Windsor/MicroKernel/Handlers/ParentHandlerWrapper.cs
@@ -62,6 +62,11 @@ namespace Castle.MicroKernel.Handlers
 			Dispose(true);
 		}
 
+		IKernel IHandler.GetKernel()
+		{
+			return parentHandler.GetKernel();
+		}
+
 		public virtual void Init(IKernelInternal kernel)
 		{
 		}

--- a/src/Castle.Windsor/MicroKernel/IHandler.cs
+++ b/src/Castle.Windsor/MicroKernel/IHandler.cs
@@ -82,5 +82,11 @@ namespace Castle.MicroKernel
 		/// </summary>
 		/// <returns></returns>
 		object TryResolve(CreationContext context);
+
+		/// <summary>
+		/// Needed to support root scope for multiple container when integrating with .NET 8
+		/// DI engine.
+		/// </summary>
+		IKernel GetKernel();
 	}
 }


### PR DESCRIPTION
This Pull Request contains also all modification by Alessandro Giorgetti already made in PR #664 related to issue #646 

This Pull Request aim to give Castle.Windsor.Extensions.DependencyInjection full support to .NET 8 new DI model with keyed service. The reason of this Fork was the inability to upgrade ours production code to .NET 8 due to internal error in Castle.Windsor. This problem happens especially with Microsoft Orleans 8 and sometimes code running on Kestrel 8. 

1. Modified code to support KeyedService in .NET 8. All basic test from framework passes, also this pr contains some other tests that idenfy some problem that occurred in our production code
2. Scope management: Orleans 8 changed how it resolves grains so we always got a null Root Scope. This happens because the Root Scope is marked with AsyncLocal, but Orleans uses thread differently so that AsyncLocal is always null. 
3. We introduced a modification in base Castle.Windsor to allow for IHandler to return the current kernel object. While this is somewhat an Hack, it was the only way for us to find the correct root scope when that AsyncLocal is null. This Hack can be avoided if we always use one single instance container, but this is a too restrictive situation.

We actually start using this code in our production code, because without these modification we have as only option to use Orleans 8 to entirely remove Castle.Windsor from our project (An extemely big work) so this code, starting from today, is running in our solution.

Feel free to ask any information or require modification in code if you feel that something is wrong.

Thanks.