### PR TITLE
Use Root scope when current is null (fixes #646)

### DIFF
--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScope.cs
@@ -35,9 +35,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 
 		public override void Dispose()
 		{
-			if (ExtensionContainerScopeCache.current.Value == this)
+			if (ExtensionContainerScopeCache.TryCurrent == this)
 			{
-				ExtensionContainerScopeCache.current.Value = parent;
+				ExtensionContainerScopeCache.Current = parent;
 			}
 			base.Dispose();
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ExtensionContainerScopeCache.cs
@@ -19,7 +19,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 
 	internal static class ExtensionContainerScopeCache
 	{
-		internal static readonly AsyncLocal<ExtensionContainerScopeBase> current = new AsyncLocal<ExtensionContainerScopeBase>();
+		private static readonly AsyncLocal<ExtensionContainerScopeBase> current = new AsyncLocal<ExtensionContainerScopeBase>();
 		/// <summary>Current scope for the thread. Initial scope will be set when calling BeginRootScope from a ExtensionContainerRootScope instance.</summary>
 		/// <exception cref="InvalidOperationException">Thrown when there is no scope available.</exception>
 		internal static ExtensionContainerScopeBase Current
@@ -27,5 +27,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 			get => current.Value ?? throw new InvalidOperationException("No scope available");
 			set => current.Value = value;
 		}
+
+		internal static ExtensionContainerScopeBase TryCurrent => current.Value;
 	}
 }

--- a/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ForcedScope.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/Scope/ForcedScope.cs
@@ -23,9 +23,9 @@ namespace Castle.Windsor.Extensions.DependencyInjection.Scope
 	{
 		private readonly ExtensionContainerScopeBase scope;
 		private readonly ExtensionContainerScopeBase previousScope;
-		internal ForcedScope(ExtensionContainerScopeBase scope)
+		internal ForcedScope(ExtensionContainerScopeBase scope, ExtensionContainerRootScope rootScope)
 		{
-			previousScope = ExtensionContainerScopeCache.Current;
+			previousScope = ExtensionContainerScopeCache.TryCurrent ?? rootScope;
 			this.scope = scope;
 			ExtensionContainerScopeCache.Current = scope;
 		}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorScopedServiceProvider.cs
@@ -30,16 +30,19 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 		private bool disposing;
 
 		private readonly IWindsorContainer container;
+
+		private readonly ExtensionContainerRootScope rootScope;
 		
-		public WindsorScopedServiceProvider(IWindsorContainer container)
+		public WindsorScopedServiceProvider(IWindsorContainer container, ExtensionContainerRootScope rootScope)
 		{
 			this.container = container;
-			scope = ExtensionContainerScopeCache.Current;
+			this.scope = ExtensionContainerScopeCache.Current;
+			this.rootScope = rootScope;
 		}
 
 		public object GetService(Type serviceType)
 		{
-			using(_ = new ForcedScope(scope))
+			using(_ = new ForcedScope(scope, rootScope))
 			{
 				return ResolveInstanceOrNull(serviceType, true);	
 			}
@@ -47,7 +50,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 
 		public object GetRequiredService(Type serviceType)
 		{
-			using(_ = new ForcedScope(scope))
+			using(_ = new ForcedScope(scope, rootScope))
 			{
 				return ResolveInstanceOrNull(serviceType, false);	
 			}

--- a/src/Castle.Windsor.Extensions.DependencyInjection/WindsorServiceProviderFactoryBase.cs
+++ b/src/Castle.Windsor.Extensions.DependencyInjection/WindsorServiceProviderFactoryBase.cs
@@ -103,6 +103,7 @@ namespace Castle.Windsor.Extensions.DependencyInjection
 			container.Register(Component
 				.For<IServiceProvider, ISupportRequiredService>()
 				.ImplementedBy<WindsorScopedServiceProvider>()
+				.DependsOn(Dependency.OnValue<ExtensionContainerRootScope>(rootScope))
 				.LifeStyle.ScopedToNetServiceScope());
 		}
 


### PR DESCRIPTION
Fixes #646 by using Root scope when current scope in `ExtensionContainerScopeCache.current` is `null`. This can happen when `WindsorScopedServiceProvider` is called from a new thread (or rather different async context).

In this situation `ForcedScope` uses the original root scope. It also restores it as `ExtensionContainerScopeCache.current` on dispose.

The only case that I haven't figured out is when resolving directly via `IWindsorContainer` (and not through `IServiceProvider`) on a new thread. `ExtensionContainerScopeAccessor.GetScope` still throws "No scope available"